### PR TITLE
Forgotten multithreaded.frm in distribution

### DIFF
--- a/check/Makefile.am
+++ b/check/Makefile.am
@@ -35,4 +35,5 @@ EXTRA_DIST = \
 	features.frm \
 	fixes.frm \
 	forcer/forcer.frm \
-	formunit/fu.frm
+	formunit/fu.frm \
+	multithreaded/multithreaded.frm


### PR DESCRIPTION
This PR simply adds `multithreaded.frm` to `EXTRA_DIST` (but it will lead to a conflict with #517).

Alternatively, it may not be necessary to add it to the distribution. In fact, `make check` does not run tests in subdirectories:
- `checkpoint/checkpoint.frm`
- `forcer/forcer.frm`
- `multithreaded/multithreaded.frm`

Unless we implement a comprehensive testing option like `make check-full`, these files may not be needed by users.

Consequently, we might consider removing these files from `EXTRA_DIST` instead.