### PR TITLE
doc: fix improper syntax in diagram generator examples

### DIFF
--- a/check/examples.frm
+++ b/check/examples.frm
@@ -1930,7 +1930,7 @@ Print;
     Set pp:p1,...,p{3*`LOOPS'};
     Set empty:;
     Local F = diagrams_(PHI3,{phi,phi},empty,QQ,pp,`LOOPS',
-            'OnePI_'+`NoTadpoles\_'+`Symmetrize_'+`TopologiesOnly_');
+            `OnePI_'+`NoTadpoles_'+`Symmetrize_'+`TopologiesOnly_');
     .end
     assert succeeded?
     assert nterms("F") == 2793
@@ -1946,7 +1946,7 @@ Print;
 *    Set pp:p1,...,p{3*`LOOPS'};
 *    Set empty:;
 *    Local F = diagrams_(PHI3,{phi,phi},empty,QQ,pp,`LOOPS',
-*            'OnePI_'+`NoTadpoles\_'+`TopologiesOnly_');
+*            `OnePI_'+`NoTadpoles_'+`TopologiesOnly_');
 *    .end
 *    assert succeeded?
 *    assert nterms("F") == 4999

--- a/doc/manual/diagrams.tex
+++ b/doc/manual/diagrams.tex
@@ -421,7 +421,7 @@ The program to do this with the diagrams\_ function is:
     Set pp:p1,...,p{3*`LOOPS'};
     Set empty:;
     Local F = diagrams_(PHI3,{phi,phi},empty,QQ,pp,`LOOPS',
-            'OnePI_'+`NoTadpoles\_'+`Symmetrize_'+`TopologiesOnly_');
+            `OnePI_'+`NoTadpoles_'+`Symmetrize_'+`TopologiesOnly_');
     .end
 
 Time =       0.85 sec    Generated terms =       2793
@@ -442,7 +442,7 @@ and without the symmetry:
     Set pp:p1,...,p{3*`LOOPS'};
     Set empty:;
     Local F = diagrams_(PHI3,{phi,phi},empty,QQ,pp,`LOOPS',
-            'OnePI_'+`NoTadpoles\_'+`TopologiesOnly\_');
+            `OnePI_'+`NoTadpoles_'+`TopologiesOnly_');
     .end
 
 Time =       0.15 sec    Generated terms =       4999


### PR DESCRIPTION
`` `...' `` is recommended over `` '...' `` in preprocessing.