### PR TITLE
Warn by default if parallel execution is vetoed due to dollar variables

### DIFF
--- a/check/examples.frm
+++ b/check/examples.frm
@@ -519,6 +519,7 @@ EOF
     #$a = 0;
     if ( count(x,1) > $a ) $a = count_(x,1);
     Print "      >> After %t the maximum power of x is %$",$a;
+    ModuleOption noparallel; * suppresses noparallel warning
     #write "     ># $a = `$a'"
     .sort
     #write "     ># $a = `$a'"
@@ -729,6 +730,7 @@ assert result("G") =~ expr("
     id,all,$t*replace_(<p1,p1?>,...,<p5,p5?>) =
          $t*replace(<p1,q1>,...,<p5,q5>);
     Print +s;
+    ModuleOption local $t; * allow parallel execution
     .end
     assert succeeded?
     assert result("F") =~ expr("
@@ -1330,6 +1332,7 @@ assert result("F") =~ expr("
       Print "Factor %$ of %$ is %$",$i,$b,$b[$i];
     enddo;
     Print;
+    ModuleOption noparallel; * suppresses noparallel warning
     .end
     assert succeeded?
     assert result("F", 0) =~ expr("

--- a/check/fixes.frm
+++ b/check/fixes.frm
@@ -316,6 +316,7 @@ endinside;
 P " a=%$;", $a;
 $a = f($a);
 P " a=%$;", $a;
+ModuleOption local $a;
 .end
 assert succeeded?
 assert result("a", 0) =~ expr("f*f(1)")
@@ -427,6 +428,7 @@ inexpression F3;
     multiply num($F3[$i]);
   enddo;
 endinexpression;
+ModuleOption local $i,$F3;
 
 .sort
 
@@ -547,6 +549,7 @@ L   Diagrams=
 
    $color = $color * topo($topo);
 
+   ModuleOption noparallel;
 .sort
 L Color = `$color';
 P;
@@ -854,6 +857,7 @@ L F = 1;
 #$x = x;
 id $x^n? = 1;
 P;
+ModuleOption local $x;
 .end
 assert succeeded?
 assert result("F") =~ expr("1")
@@ -865,6 +869,7 @@ L F = x^3 * y^5 * p.q^6;
 #$x = x*y*p.q;
 id $x^n? = z^n;
 P;
+ModuleOption local $x;
 .end
 assert succeeded?
 assert result("F") =~ expr("p.q^3*y^2*z^3")
@@ -1643,6 +1648,7 @@ if ($n == 0);
   P "Error: F[%$] == %$", $x, $y;
   redefine failed "1";
 endif;
+ModuleOption local $n,$x,$y;
 .sort:test;
 
 #if `failed'
@@ -1705,6 +1711,7 @@ L G = 1 + x + x^2;
 $x = f(count_(x,1));
 multiply $x;
 P;
+ModuleOption local $x;
 .end
 assert succeeded?
 assert result("F") =~ expr("f(0) + f(0)*x + f(0)*x^2")
@@ -1834,6 +1841,7 @@ L F = f(x1,...,x4);
 id f(?a$a) = 1;
 multiply distrib_(1,1,f,dummy_,$a);
 P;
+ModuleOption local $a;
 .end
 assert succeeded?
 assert result("F") =~ expr("f(x1) + f(x2) + f(x3) + f(x4)")
@@ -2532,6 +2540,7 @@ DropCoefficient;
 Multiply tag($i);
 $i = $i+1;
 Print +s;
+ModuleOption noparallel;
 .sort
 
 * Everything should cancel in the end, and we should get zero.
@@ -2594,6 +2603,7 @@ DropCoefficient;
 Multiply tag($i);
 $i = $i+1;
 Print +s;
+ModuleOption noparallel;
 .sort
 
 * Everything should cancel in the end, and we should get zero.

--- a/check/fixes.frm
+++ b/check/fixes.frm
@@ -3880,6 +3880,91 @@ P G;
 assert succeeded?
 assert result("G") =~ expr("389")
 *--#] PullReq535 :
+*--#[ PullReq649_1 :
+* Test warning message when modifying a dollar variable forces
+* a module into sequential mode
+
+*  need an expression with a non-zero value
+Local expr = 1;
+*  and a new module, since parallel execution does not work
+*  in the module defining an expression
+.sort
+$a = 1;
+.end
+#require threaded?
+assert warning?("This module is forced to run in sequential mode due to $-variable: $a")
+*--#] PullReq649_1 :
+*--#[ PullReq649_2 :
+* same as `PullReq649_1` with a longer variable name
+Local expr = 1;
+.sort
+$n1MdWu6rNU1d29yW3ukhzV7YuY = 1;
+.end
+#require threaded?
+assert warning?("This module is forced to run in sequential mode due to $-variable: $n1MdWu6rNU1d29yW3ukhzV7YuY")
+*--#] PullReq649_2 :
+*--#[ PullReq649_3 :
+* assigning in the preprocessor should not veto parallel execution
+Local expr = 1;
+.sort
+#$a = 1;
+.end
+assert succeeded?
+*--#] PullReq649_3 :
+*--#[ PullReq649_4 :
+* assigning through pattern matching
+Local expr = 1;
+.sort
+Symbol x;
+id x?$a = x;
+.end
+#require threaded?
+assert warning?("This module is forced to run in sequential mode due to $-variable: $a")
+*--#] PullReq649_4 :
+* don't veto parallel execution if there is a matching moduleoption statement
+*--#[ PullReq649_5 :
+Local expr = 1;
+.sort
+$a = 1;
+moduleoption local $a;
+.end
+assert succeeded?
+*--#] PullReq649_5 :
+*--#[ PullReq649_6 :
+Local expr = 1;
+.sort
+$a = 1;
+moduleoption sum $a;
+.end
+assert succeeded?
+*--#] PullReq649_6 :
+*--#[ PullReq649_7 :
+Local expr = 1;
+.sort
+$a = 1;
+moduleoption minimum $a;
+.end
+assert succeeded?
+*--#] PullReq649_7 :
+*--#[ PullReq649_8 :
+Local expr = 1;
+.sort
+$a = 1;
+moduleoption maximum $a;
+.end
+assert succeeded?
+*--#] PullReq649_8 :
+*--#[ PullReq649_9 :
+* *do veto* if the moduleoption statement is for the wrong variable
+Local expr = 1;
+.sort
+#$b = 1;
+$a = 1;
+moduleoption local $b;
+.end
+#require threaded?
+assert warning?("This module is forced to run in sequential mode due to $-variable: $a")
+*--#] PullReq649_9 :
 *--#[ PullReq652 :
 #-
 Off statistics;

--- a/doc/manual/polynomials.tex
+++ b/doc/manual/polynomials.tex
@@ -499,6 +499,7 @@ Factor 4 of -y^4+x^4 is y^2+x^2
       Print "Factor %$ of %$ is %$",$i,$b,$b[$i];
     enddo;
     Print;
+    ModuleOption noparallel; * suppresses noparallel warning with TFORM
     .end
 Factor 1 of -y^4+x^4 is -1
 Factor 2 of -y^4+x^4 is y-x

--- a/doc/manual/statements.tex
+++ b/doc/manual/statements.tex
@@ -2390,6 +2390,7 @@ the if(match()) construction. It would not make sense there anyway.}
     id,all,$t*replace_(<p1,p1?>,...,<p5,p5?>) =
          $t*replace(<p1,q1>,...,<p5,q5>);
     Print +s;
+    ModuleOption noparallel; * suppresses noparallel warning with TFORM
     .end
 
    F =

--- a/sources/execute.c
+++ b/sources/execute.c
@@ -802,7 +802,7 @@ WORD DoExecute(WORD par, WORD skip)
 			/* The user switched off the parallel execution explicitly. */
 		}
 		else if ( AC.mparallelflag & NOPARALLEL_DOLLAR ) {
-			if ( AC.WarnFlag >= 2 ) {  /* HighWarning */
+			if ( AC.WarnFlag >= 1 ) {  /* Warning */
 				int i, j, k, n;
 				UBYTE *s, *s1;
 				s = strDup1((UBYTE *)"","NOPARALLEL_DOLLAR s");
@@ -825,7 +825,7 @@ WORD DoExecute(WORD par, WORD skip)
 					s1 = AddToString(s1,(UBYTE *)"s",0);
 				s1 = AddToString(s1,(UBYTE *)": ",0);
 				s1 = AddToString(s1,s,0);
-				HighWarning((char *)s1);
+				Warning((char *)s1);
 				M_free(s,"NOPARALLEL_DOLLAR s");
 				M_free(s1,"NOPARALLEL_DOLLAR s1");
 			}


### PR DESCRIPTION
Before this commit FORM only warns when disabling parallel execution in a module if `on allwarnings` is set. This makes sense, since for most of the causes it is not straightforward to modify the code in a way that re-enables parallel execution. However, modifying a dollar variable without a corresponding `moduleoption` statement is often a trivial bug and the user should be warned by default.