### PR TITLE
fix: putfirst_ for un-equally sized args

### DIFF
--- a/check/fixes.frm
+++ b/check/fixes.frm
@@ -3774,6 +3774,40 @@ assert stdout =~ exact_pattern(<<'EOF')
    {}: -10 -20 30
 EOF
 *--#] Issue599 : 
+*--#[ Issue642 :
+#-
+Off statistics;
+
+CFunction d;
+CFunction f,g;
+Symbol a,b,c;
+CFunction h;
+
+Local F =
+*	Example terms with args that are in fast notation and full expressions
+	+ f(1,a,2)
+	+ f(1,-a,2)
+	+ f(1,a+b,2)
+	+ f(1,h,2)
+	+ f(1,h(1,2),2)
+	+ f(1,h(a),2)
+	+ f(1,h(a)+a,2)
+	;
+Identify f(?a) = f(?a) - g(?a);
+* Produce test terms where f appears at the beginning, end,
+* and in the middle of the term data.
+Multiply 1+d(1,2,3);
+Multiply 1+h(1,2,3);
+.sort
+
+Identify f(?a) = putfirst_(f,2,?a);
+Identify g(a?,b?,c?) = f(b,a,c);
+
+Print;
+.end
+assert succeeded?
+assert result("F") =~ expr("0")
+*--#] Issue642 :
 *--#[ PullReq535 :
 * This test requires more than the specified 50K workspace.
 #:maxtermsize 200


### PR DESCRIPTION
Store a pointer to the argument which trails the selected one. The pointer to the selected argument can not be advanced, as it is written over if the terms are different sizes (which accidentally worked previously).

Fixes #642

It is a bit surprising, that this one was only discovered recently.