### PR TITLE
fix: euler sums without arguments.

### DIFF
--- a/sources/float.c
+++ b/sources/float.c
@@ -2311,6 +2311,8 @@ int EvaluateEuler(PHEAD WORD *term, WORD level, WORD par)
 				sumweight += ABS(tt[1]); depth++;
 				tt += 2;
 			}
+			/* euler sum without arguments, i.e. mzv_(), euler_() or mzvhalf_() */
+			if ( depth == 0) goto nextfun;
 			if ( sumweight > AC.MaxWeight ) {
 				MesPrint("Error: Weight of Euler/MZV sum greater than %d",sumweight);
 				MesPrint("Please increase MaxWeight in form.set.");


### PR DESCRIPTION
This resolves #646: `mzv_`, `euler_` or `mzvhalf_` without argument. 