### PR TITLE
fix: regression in par=2 EndSort

### DIFF
--- a/sources/sort.c
+++ b/sources/sort.c
@@ -997,7 +997,8 @@ TooLarge:
 							}
 							*((WORD **)buffer) = to;
 							NCOPY(to,t,jj);
-							retval = to - buffer - 1;
+							/* we should not set retval here in this par==2 case, it being 0 has meaning
+							   after RetRetval, and it is set properly there. */
 						}
 						else {
 							j = newout->POfill - t;


### PR DESCRIPTION
Revert one change of 1900651, which broke things in case a par=2 EndSort ends up in a file or PObuffer