### PR TITLE
ci: fetch color.h from the form-packages mirror

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,7 +72,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: formlib
-          key: formlib-${{ matrix.test }}
+          key: formlib-${{ matrix.test }}-v1
 
       - name: Install library if necessary
         if: steps.cache-formlib.outputs.cache-hit != 'true'
@@ -86,7 +86,9 @@ jobs:
               mv forcer-1.0.0/forcer formlib
               rm -rf forcer-1.0.0
               # color library for the color test in extra
-              wget https://www.nikhef.nl/~form/maindir/packages/color/color.h -P formlib
+              wget https://github.com/form-dev/form-packages/archive/refs/tags/v1.0.0.tar.gz -O - | tar -x --gzip
+              mv form-packages-1.0.0/color/color.h formlib
+              rm -rf form-packages-1.0.0
               ;;
           esac
 
@@ -148,7 +150,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: formlib
-          key: formlib-${{ matrix.test }}
+          key: formlib-${{ matrix.test }}-v1
 
       - name: Install library if necessary
         if: steps.cache-formlib.outputs.cache-hit != 'true'
@@ -162,7 +164,9 @@ jobs:
               mv forcer-1.0.0/forcer formlib
               rm -rf forcer-1.0.0
               # color library for the color test in extra
-              wget https://www.nikhef.nl/~form/maindir/packages/color/color.h -P formlib
+              wget https://github.com/form-dev/form-packages/archive/refs/tags/v1.0.0.tar.gz -O - | tar -x --gzip
+              mv form-packages-1.0.0/color/color.h formlib
+              rm -rf form-packages-1.0.0
               ;;
           esac
 
@@ -247,7 +251,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: formlib
-          key: formlib-${{ matrix.test }}
+          key: formlib-${{ matrix.test }}-v1
 
       - name: Install library if necessary
         if: steps.cache-formlib.outputs.cache-hit != 'true'
@@ -261,7 +265,9 @@ jobs:
               mv forcer-1.0.0/forcer formlib
               rm -rf forcer-1.0.0
               # color library for the color test in extra
-              wget https://www.nikhef.nl/~form/maindir/packages/color/color.h -P formlib
+              wget https://github.com/form-dev/form-packages/archive/refs/tags/v1.0.0.tar.gz -O - | tar -x --gzip
+              mv form-packages-1.0.0/color/color.h formlib
+              rm -rf form-packages-1.0.0
               ;;
           esac
 
@@ -330,7 +336,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: formlib
-          key: formlib-${{ matrix.test }}
+          key: formlib-${{ matrix.test }}-v1
 
       - name: Install library if necessary
         if: steps.cache-formlib.outputs.cache-hit != 'true'
@@ -344,7 +350,9 @@ jobs:
               mv forcer-1.0.0/forcer formlib
               rm -rf forcer-1.0.0
               # color library for the color test in extra
-              wget https://www.nikhef.nl/~form/maindir/packages/color/color.h -P formlib
+              wget https://github.com/form-dev/form-packages/archive/refs/tags/v1.0.0.tar.gz -O - | tar -x --gzip
+              mv form-packages-1.0.0/color/color.h formlib
+              rm -rf form-packages-1.0.0
               ;;
           esac
 


### PR DESCRIPTION
Timeouts fetching `color.h` from `nikhef.nl` are causing problems every time the formlib cache needs to be updated.

- Fetch form packages from a mirror: https://github.com/form-dev/form-packages
- Add a `-v1` tag to the cache key, which can be incremented when new files are added, so we don't need to remove the existing cache through the github UI.