### PR TITLE
test: further fix the timeout test to avoid false failures

### DIFF
--- a/check/features.frm
+++ b/check/features.frm
@@ -303,12 +303,13 @@ assert succeeded?
 #timeoutafter 0
 .end
 #require unix?
-# ParFORM may terminate without printing the error message,
-# depending on the MPI environment.
+# Sometimes, FORM can terminate without printing the error message, so don't
+# assert anything. We only test whether this hits the test suite timeout limit,
+# or not. TODO in principle this can be considered to be a bug, to be looked at
+# in the future.
+# For parform, there is no attempt to ensure the master process recieves SIGALRM
+# and not the workers.
 #pend_if mpi?
-# Sometimes, FORM will terminate after 1s without a runtime error.
-# TODO: this should be considered a bug.
-assert succeeded? || runtime_error?
 *--#] TimeoutAfter_2 :
 *--#[ dedup :
 * Test deduplication


### PR DESCRIPTION
FORM can terminate on timeout without printing an error message, with exit status != 0, so assert succeeded? || runtime_error? is not sufficient to catch this. Just don't assert anything. Hitting the test suite timeout still results in a failed test.