### PR TITLE
perf: tform: remove default-enabled compare count

### DIFF
--- a/sources/sort.c
+++ b/sources/sort.c
@@ -72,7 +72,13 @@ extern LONG nummallocs;
 extern LONG numfrees;
 #endif
 
-LONG numcompares;
+//#define COUNTCOMPARES
+#ifdef COUNTCOMPARES
+	// This needs to be large enough for the number of threads.
+	// It is hardcoded here, but 1024 should be enough.
+	// Enabling this has a performance impact.
+	LONG numcompares[1024];
+#endif
 
 /*
   	#] Includes : 
@@ -659,7 +665,13 @@ WORD NewSort(PHEAD0)
 	}
 	if ( AR.sLevel == 0 ) {
 
-		numcompares = 0;
+#ifdef COUNTCOMPARES
+#ifdef WITHPTHREADS
+		numcompares[AT.identity] = 0;
+#else
+		numcompares[0] = 0;
+#endif
+#endif
 
 		AN.FunSorts[0] = AT.S0;
 		if ( AR.PolyFun == 0 ) { AT.S0->PolyFlag = 0; }
@@ -1267,11 +1279,19 @@ RetRetval:
 			newout = 0;
 		}
 	}
-/*
+
+#ifdef COUNTCOMPARES
 	if ( AR.sLevel < 0 ) {
-		MesPrint(" number of calls to compare was %l",numcompares);
+#ifdef WITHPTHREADS
+		MLOCK(ErrorMessageLock);
+		MesPrint(">>>number of calls to Compare: %l (tid %d)", numcompares[AT.identity], AT.identity);
+		MUNLOCK(ErrorMessageLock);
+#else
+		MesPrint(">>>number of calls to Compare: %l", numcompares[0]);
+#endif
 	}
-*/
+#endif
+
 	return(retval);
 WorkSpaceError:
 	MLOCK(ErrorMessageLock);
@@ -2627,9 +2647,15 @@ WORD Compare1(PHEAD WORD *term1, WORD *term2, WORD level)
 	WORD prevorder;
 	WORD count = -1, localPoly, polyhit = -1;
 
+#ifdef COUNTCOMPARES
 	if ( AR.sLevel == 0 ) {
-		numcompares++;
+#ifdef WITHPTHREADS
+		numcompares[AT.identity]++;
+#else
+		numcompares[0]++;
+#endif
 	}
+#endif
 
 	if ( S->PolyFlag ) {
 /*


### PR DESCRIPTION
For scripts which are dominated by level-0 sorting, counting the compares (and not even printing the result) leads to a large performance impact.

Disabled the counting by default.

The per-thread counter still leads to a performance impact, though it is smaller.

---------

This counter was introduced in f1b83ae, which adds the partial binary search to SplitMerge. There a 1.5% performance improvement is claimed for mincer. Possibly this was determined with a single-threaded test?

This change (default: no counter) compared to current master:

| Test | master (s) | Speedup |
|------|--------------|---------|
|trace|5.09|4.51x|
|mincer|70.57|1.28x|
|mass-fact|59.38|1.12x
|forcer|122.23|1.02x|
|mbox1l|2.73|1.00x|

`forcer` and `mbox1l` tests spend a lot of time sorting polyratfun, so they have much less level-0 sorting time.

Please try your own performance tests and let me know if this is observed on other systems. Here I use 24 threads.