### PR TITLE
build: disable native by default

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -123,12 +123,12 @@ debugging versions can be specified by the environment variables
   DEBUGCOMPILEFLAGS
   DEBUGLINKFLAGS
 If they are not set, they will be chosen for the local machine where you are
-compiling executables, which may contain optimization flags that makes
-executables incompatible with other machines. If you plan to move the
-executables to other machines and want to avoid such incompatibility, use the
-following option:
+compiling executables. If you would like to enable additional optimizations
+specific to the machine on which you are compiling FORM, use the following
+option. Note that the resulting binary may not run on CPUs with a different
+feature set.
 
-    ./configure --disable-native
+    ./configure --enable-native
 
 The configure script creates a file "config.h" in which several options and
 settings are passed on to the source code files via preprocessor definitions.

--- a/configure.ac
+++ b/configure.ac
@@ -827,10 +827,10 @@ AC_SUBST([MPI_STATIC_LDFLAGS])
 # Check for native/universal build
 AC_ARG_ENABLE([native],
 	[AS_HELP_STRING([--enable-native],
-		[tune for the compiling machine (release versions) @<:@default=yes@:>@])],
+		[tune for the compiling machine (release versions) @<:@default=no@:>@])],
 	[AS_IF([test "x$enableval" = xno || test "x$cross_compiling" = xyes],
 		[enable_native=no], [enable_native=yes])],
-	[enable_native=yes])
+	[enable_native=no])
 
 # Check for profiling option
 AC_ARG_ENABLE([profile],


### PR DESCRIPTION
To maximise compatibility when running on clusters of machines with different CPU feature sets, don't compile with march=native by default.

This anyway doesn't appear to improve performance and possibly even causes perfomance loss: https://github.com/form-dev/form/discussions/705