### PR TITLE
fix: memory leak in pre-processor dollar var increment

### DIFF
--- a/check/fixes.frm
+++ b/check/fixes.frm
@@ -3943,6 +3943,19 @@ Evaluate 1;
 #pend_if wordsize == 2
 assert compile_error?("should be a built in function that can be evaluated numerically.")
 *--#] Issue664 :
+*--#[ Issue666 :
+#-
+#$repcount = 1;
+Local test = 1;
+Multiply 2;
+.sort:iter `$repcount++';
+Multiply 2;
+.sort:iter `$repcount++';
+Print;
+.end
+assert succeeded?
+assert result("test") =~ expr("4")
+*--#] Issue666 :
 *--#[ Issue668_1 :
 * Check error message for invalid setup parameter:
 #:x

--- a/sources/tools.c
+++ b/sources/tools.c
@@ -736,6 +736,8 @@ STREAM *CloseStream(STREAM *stream)
 		if ( stream->afterwards == PRERAISEAFTER ) x = 1;
 		else x = -1;
 		DollarRaiseLow(stream->pname,x);
+		if ( stream->buffer ) M_free(stream->buffer,"stream->buffer");
+		stream->buffer = 0;
 	}
 	else if ( stream->type == PRECALCSTREAM || stream->type == DOLLARSTREAM ) {
 		if ( stream->buffer ) M_free(stream->buffer,"stream->buffer");


### PR DESCRIPTION
This memory is allocated in WriteDollarToBuffer as "DollarOutBuffer" and then stored in stream->buffer by OpenStream. We must free it in CloseStream in the PRERAISEAFTER/PRELOWERAFTER case.

This closes #666 .