### PR TITLE
fix: memory leak due to nested procedure definitions

### DIFF
--- a/sources/structs.h
+++ b/sources/structs.h
@@ -884,6 +884,7 @@ typedef struct {
 	PRELOAD p;
 	UBYTE	*name;
 	int		loadmode;
+	int		mustfree;
 	PADPOINTER(0,1,0,0);
 } PROCEDURE;
 


### PR DESCRIPTION
Decouple the procedure "loadmode" from whether or not we need to free the allocated memory in DoEndprocedure. Detected nested procedures in DoProcedure and set an additional flag to trigger the free.

This closes #252