### PR TITLE
Update actions/checkout to v6 in 32-bit containers

### DIFF
--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -270,13 +270,20 @@ runs:
           echo "CONFIG_ARGS=$args" >>"$GITHUB_ENV"
         fi
 
+        # Fix dubious ownership in containers for Git operations.
+        # See: https://github.com/actions/runner/issues/2033#issuecomment-1204205989
+
+        if $feat_container; then
+          chown -R "$(id -u):$(id -g)" "$PWD"
+        fi
+
         # Determine DISTNAME if possible.
 
         if [ -f ./scripts/git-version-gen.sh ] && command -v git >/dev/null 2>&1; then
           echo "DISTNAME=form-$(./scripts/git-version-gen.sh -r | sed '2q;d' | sed 's/^v//')" >>"$GITHUB_ENV"
         fi
 
-        # Get cache key for the image ###
+        # Get cache key for the image.
 
         # See: https://github.com/actions/upload-artifact/issues/231
         echo "image_key=$ImageOS-$ImageVersion" >>"$GITHUB_OUTPUT"
@@ -584,16 +591,6 @@ runs:
       if: steps.setup.outputs.hyperform == 'true'
       shell: ${{ steps.setup.outputs.msys2 == 'true' && 'msys2 {0}' || 'bash' }}
       run: cp formlib/hyperform.frm check/extra/
-
-    # Fix dubious ownership in containers for Git operations.
-    # See: https://github.com/actions/runner/issues/2033#issuecomment-1204205989
-    - name: Fix dubious ownership
-      if: steps.setup.outputs.container == 'true'
-      shell: bash
-      run: |
-        ### Fix dubious ownership
-
-        chown -R $(id -u):$(id -g) $PWD
 
     - name: Uncompress tarball
       if: steps.setup.outputs.untar == 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -249,15 +249,27 @@ jobs:
           - {bin: tform}
           - {bin: tform, nthreads: 2}
     steps:
-      # We have to use v1.
-      # See https://github.com/actions/checkout/issues/334
+      # 32-bit containers lack the amd64 libstdc++ runtime library needed by
+      # the runner-provided Node.js runtime.
+      # See: https://github.com/EliahKagan/gitoxide/pull/5
+      #
+      # Install Git so that actions/checkout can create a local Git repository
+      # instead of downloading the files through the GitHub REST API.
+      - name: Prerequisites for 32-bit containers
+        run: |
+          dpkg --add-architecture amd64
+          apt-get update
+          apt-get install --no-install-recommends -y ca-certificates git libstdc++6:amd64
+
       - name: Checkout repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0  # ensures a reachable tag
 
       - name: Set up build
         uses: ./.github/actions/setup-build
         with:
-          features: ${{ matrix.bin }} noflint  # actions/cache@v4 doesn't work
+          features: ${{ matrix.bin }} noflint  # The FLINT interface currently assumes a 64-bit environment.
 
       - name: Build
         run: make -C sources -j 4 ${{ matrix.bin }}


### PR DESCRIPTION
This PR fixes problems that occur when using `actions/checkout@v6` in 32-bit containers.

~FLINT can also be tested if the paths are adjusted.~

For background on the Node.js runtime dependency issue in 32-bit containers, see:
- https://github.com/actions/checkout/issues/334
- https://github.com/EliahKagan/gitoxide/pull/5