### PR TITLE
Enabling Dependabot version updates for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
After the following PRs are merged:

- https://github.com/form-dev/form/pull/841
- https://github.com/form-dev/form/pull/846

it would be a good idea to enable [Dependabot version updates](https://docs.github.com/en/code-security/concepts/supply-chain-security/dependabot-version-updates) to automatically update GitHub Action dependencies.