### PR TITLE
Hide code from coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -216,7 +216,7 @@ jobs:
 
       - name: Generate LCOV coverage data
         run: |
-          lcov -d . -c -o coverage.lcov
+          lcov --config-file .lcovrc -d . -c -o coverage.lcov
           lcov -r coverage.lcov '*/usr/include/*' '*/extern/*'${{ matrix.flint != 'no' && ' ''*/lib/*''' || '' }} -o coverage.lcov
 
       - name: Coveralls Parallel

--- a/.lcovrc
+++ b/.lcovrc
@@ -1,0 +1,8 @@
+# FORM-specific LCOV exclusion markers:
+# 
+# - INTERNAL_ERROR_EXCL_...: exclude internal errors from the coverage statistics
+# - UNFINISHED_FEATURE_EXCL_...: exclude unfinished features code.
+# 
+lcov_excl_start = (INTERNAL_ERROR_EXCL_START|UNFINISHED_FEATURE_EXCL_START)
+lcov_excl_stop = (INTERNAL_ERROR_EXCL_STOP|UNFINISHED_FEATURE_EXCL_STOP)
+lcov_excl_line = (INTERNAL_ERROR_EXCL_LINE|UNFINISHED_FEATURE_EXCL_LINE)

--- a/.lcovrc
+++ b/.lcovrc
@@ -1,8 +1,9 @@
 # FORM-specific LCOV exclusion markers:
 # 
-# - INTERNAL_ERROR_EXCL_...: exclude internal errors from the coverage statistics
-# - UNFINISHED_FEATURE_EXCL_...: exclude unfinished features code.
+# - INTERNAL_ERROR_EXCL_...: exclude internal errors from the coverage statistics,
+# - UNFINISHED_FEATURE_EXCL_...: exclude unfinished features code,
+# - DEBUG_EXCL_...: exclude code used for debugging purposes only.
 # 
-lcov_excl_start = (INTERNAL_ERROR_EXCL_START|UNFINISHED_FEATURE_EXCL_START)
-lcov_excl_stop = (INTERNAL_ERROR_EXCL_STOP|UNFINISHED_FEATURE_EXCL_STOP)
-lcov_excl_line = (INTERNAL_ERROR_EXCL_LINE|UNFINISHED_FEATURE_EXCL_LINE)
+lcov_excl_start = (INTERNAL_ERROR_EXCL_START|UNFINISHED_FEATURE_EXCL_START|DEBUG_EXCL_START)
+lcov_excl_stop = (INTERNAL_ERROR_EXCL_STOP|UNFINISHED_FEATURE_EXCL_STOP|DEBUG_EXCL_STOP)
+lcov_excl_line = (INTERNAL_ERROR_EXCL_LINE|UNFINISHED_FEATURE_EXCL_LINE|DEBUG_EXCL_LINE)

--- a/sources/checkpoint.c
+++ b/sources/checkpoint.c
@@ -80,7 +80,7 @@
   	#] License : 
   	#[ Includes :
 */
-
+/* UNFINISHED_FEATURE_EXCL_START */
 #include "form3.h"
 
 #include <errno.h>
@@ -3244,7 +3244,7 @@ void DoCheckpoint(int moduletype)
 	}/*if(PF.me != MASTER)*/
 #endif
 }
-
+/* UNFINISHED_FEATURE_EXCL_STOP */
 /*
   	#] DoCheckpoint : 
 */

--- a/sources/compcomm.c
+++ b/sources/compcomm.c
@@ -4254,7 +4254,9 @@ int CoIf(UBYTE *inp)
 	CBUF *C = cbuf+AC.cbufnum;
 	LONG x;
 #ifdef WITHFLOAT
+/* UNFINISHED_FEATURE_EXCL_START */
 	int spec;
+/* UNFINISHED_FEATURE_EXCL_STOP */
 #endif
 	if ( *inp == '(' && inp[1] == ',' ) inp += 2;
 	else if ( *inp == '(' ) inp++;	/* Usually we enter at the bracket */
@@ -4285,6 +4287,7 @@ ReDo:
 		if ( FG.cTable[*p] == 1 ) {		/* Number */
 			if ( gotexp == 1 ) { MesCerr("position for )",p); error = 1; }
 #ifdef WITHFLOAT
+/* UNFINISHED_FEATURE_EXCL_START */
 			pp = CheckFloat(p,&spec);
 			if ( pp > p ) {	/* Got one */
 HaveFloat:
@@ -4309,7 +4312,7 @@ HaveFloat:
 /*
 			Notation: Same as FLOATFUN but FLOATFUN replaced by IFFLOATNUMBER.
 */
-
+/* UNFINISHED_FEATURE_EXCL_STOP */
 #endif
 			u = w;
 			*w++ = LONGNUMBER;
@@ -4372,7 +4375,9 @@ OnlyNum:
 			u[2] = (u[1] - 3)/2;
 			if ( level ) u[2] = -u[2];
 #ifdef WITHFLOAT
+/* UNFINISHED_FEATURE_EXCL_START */
 DoneWithNumber:
+/* UNFINISHED_FEATURE_EXCL_STOP */
 #endif
 			gotexp = 1;
 		}
@@ -4772,10 +4777,12 @@ NoGood:			MesPrint("&Unrecognized word: %s",inp);
 			gotexp = 1;
 		}
 #ifdef WITHFLOAT
+/* UNFINISHED_FEATURE_EXCL_START */
 		else if ( *p == '.' ) {
 			pp = CheckFloat(p,&spec);
 			if ( pp > p ) goto HaveFloat;
 		}
+/* UNFINISHED_FEATURE_EXCL_STOP */
 #endif
 		else if ( *p == '(' ) {
 			if ( gotexp ) {

--- a/sources/compcomm.c
+++ b/sources/compcomm.c
@@ -3920,7 +3920,7 @@ int CoAntiBracket(UBYTE *inp)
 	Syntax:
 		MultiBracket:{A|B} bracketinfo:...:{A|B} bracketinfo;
 */
-
+/* UNFINISHED_FEATURE_EXCL_START */
 int CoMultiBracket(UBYTE *inp)
 {
 	GETIDENTITY
@@ -4027,7 +4027,7 @@ RegEnd:
 	AT.bracketindexflag = 0;
 	return(error);
 }
-
+/* UNFINISHED_FEATURE_EXCL_STOP */
 /*
   	#] CoMultiBracket : 
   	#[ CountComp :
@@ -7404,7 +7404,7 @@ int CoEndSwitch(UBYTE *s)
   	#] CoEndSwitch : 
   	#[ CoSetUserFlag :
 */
-
+/* UNFINISHED_FEATURE_EXCL_START */
 int CoSetUserFlag(UBYTE *s)
 {
 	int error = 0;
@@ -7427,12 +7427,12 @@ int CoSetUserFlag(UBYTE *s)
 	}
 	return(error);
 }
-
+/* UNFINISHED_FEATURE_EXCL_STOP */
 /*
   	#] CoSetUserFlag : 
   	#[ CoClearUserFlag :
 */
-
+/* UNFINISHED_FEATURE_EXCL_START */
 int CoClearUserFlag(UBYTE *s)
 {
 	int error = 0;
@@ -7455,7 +7455,7 @@ int CoClearUserFlag(UBYTE *s)
 	}
 	return(error);
 }
-
+/* UNFINISHED_FEATURE_EXCL_STOP */
 /*
   	#] CoClearUserFlag : 
   	#[ CoCreateAllLoops :

--- a/sources/diagrams.c
+++ b/sources/diagrams.c
@@ -31,7 +31,7 @@
 /*
   	#[ Includes : diagrams.c
 */
-
+/* UNFINISHED_FEATURE_EXCL_START */
 #include "form3.h"
  
 static WORD one = 1;
@@ -661,3 +661,5 @@ MesPrint("partitions = %a",2*nvert,partitions);
 /*
   	#] DoShattering : 
 */
+
+/* UNFINISHED_FEATURE_EXCL_STOP */

--- a/sources/dict.c
+++ b/sources/dict.c
@@ -1115,7 +1115,7 @@ int DoPreAdd(UBYTE *s)
   	#] DoPreAdd : 
   	#[ DictToBytes :
 */
-
+/* UNFINISHED_FEATURE_EXCL_START */
 LONG DictToBytes(DICTIONARY *dict,UBYTE *buf)
 {
 	int numelements = dict->numelements, sizeelement, i, j, x;
@@ -1143,12 +1143,12 @@ LONG DictToBytes(DICTIONARY *dict,UBYTE *buf)
 	}
 	return(s2-buf);
 }
-
+/* UNFINISHED_FEATURE_EXCL_STOP */
 /*
   	#] DictToBytes : 
   	#[ DictFromBytes :
 */
-
+/* UNFINISHED_FEATURE_EXCL_START */
 DICTIONARY *DictFromBytes(UBYTE *buf)
 {
 	DICTIONARY *dict = Malloc1(sizeof(DICTIONARY),"Dictionary");
@@ -1175,7 +1175,7 @@ DICTIONARY *DictFromBytes(UBYTE *buf)
 	}
 	return(dict);
 }
-
+/* UNFINISHED_FEATURE_EXCL_STOP */
 /*
   	#] DictFromBytes : 
 */

--- a/sources/evaluate.c
+++ b/sources/evaluate.c
@@ -238,10 +238,12 @@ int GetFloatArgument(PHEAD mpfr_t f_out,WORD *fun,int par)
 /*
 			If the argument was properly normalized we are not supposed to come here.
 */
+/* INTERNAL_ERROR_EXCL_START */
 			MLOCK(ErrorMessageLock);
-			MesPrint("Unnormalized argument in GetFloatArgument: %a",*term,term);
+			MesPrint("!>Unnormalized argument in GetFloatArgument: %a",*term,term);
 			MUNLOCK(ErrorMessageLock);
 			Terminate(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 		}
 		else if ( t[0] == SYMBOL && t[1] == 4 && t[2] == PISYMBOL && t[3] == 1 ) {
 			if ( first ) {

--- a/sources/flintinterface.cc
+++ b/sources/flintinterface.cc
@@ -100,16 +100,20 @@ WORD* flint::divmod_mpoly(PHEAD const WORD *a, const WORD *b, const bool return_
 	// The input won't have any symbols with negative powers, but there may be rational
 	// coefficients. Verify this:
 	if ( fmpz_mpoly_is_fmpz(denpa.d, ctx.d) != 1 ) {
+		// INTERNAL_ERROR_EXCL_START
 		MLOCK(ErrorMessageLock);
-		MesPrint("flint::divmod_mpoly: error: denpa is non-constant");
+		MesPrint("!>flint::divmod_mpoly: error: denpa is non-constant");
 		MUNLOCK(ErrorMessageLock);
 		Terminate(-1);
+		// INTERNAL_ERROR_EXCL_STOP
 	}
 	if ( fmpz_mpoly_is_fmpz(denpb.d, ctx.d) != 1 ) {
+		// INTERNAL_ERROR_EXCL_START
 		MLOCK(ErrorMessageLock);
-		MesPrint("flint::divmod_mpoly: error: denpb is non-constant");
+		MesPrint("!>flint::divmod_mpoly: error: denpb is non-constant");
 		MUNLOCK(ErrorMessageLock);
 		Terminate(-1);
+		// INTERNAL_ERROR_EXCL_STOP
 	}
 
 
@@ -169,16 +173,20 @@ WORD* flint::divmod_poly(PHEAD const WORD *a, const WORD *b, const bool return_r
 	// The input won't have any symbols with negative powers, but there may be rational
 	// coefficients. Verify this:
 	if ( fmpz_poly_length(denpa.d) != 1 ) {
+		// INTERNAL_ERROR_EXCL_START
 		MLOCK(ErrorMessageLock);
-		MesPrint("flint::divmod_poly: error: denpa is non-constant");
+		MesPrint("!>flint::divmod_poly: error: denpa is non-constant");
 		MUNLOCK(ErrorMessageLock);
 		Terminate(-1);
+		// INTERNAL_ERROR_EXCL_STOP
 	}
 	if ( fmpz_poly_length(denpb.d) != 1 ) {
+		// INTERNAL_ERROR_EXCL_START
 		MLOCK(ErrorMessageLock);
-		MesPrint("flint::divmod_poly: error: denpb is non-constant");
+		MesPrint("!>flint::divmod_poly: error: denpb is non-constant");
 		MUNLOCK(ErrorMessageLock);
 		Terminate(-1);
+		// INTERNAL_ERROR_EXCL_STOP
 	}
 
 	flint::fmpz scale;
@@ -241,10 +249,12 @@ WORD* flint::factorize_mpoly(PHEAD const WORD *argin, WORD *argout, const bool w
 	flint::from_argument_mpoly(arg.d, den.d, argin, with_arghead, var_map, ctx.d);
 	// The denominator must be 1:
 	if ( fmpz_mpoly_is_one(den.d, ctx.d) != 1 ) {
+		// INTERNAL_ERROR_EXCL_START
 		MLOCK(ErrorMessageLock);
-		MesPrint("flint::factorize_mpoly error: den != 1");
+		MesPrint("!>flint::factorize_mpoly error: den != 1");
 		MUNLOCK(ErrorMessageLock);
 		Terminate(-1);
+		// INTERNAL_ERROR_EXCL_STOP
 	}
 
 
@@ -258,10 +268,12 @@ WORD* flint::factorize_mpoly(PHEAD const WORD *argin, WORD *argout, const bool w
 	// FORM should always have taken the overall constant out in the content. Thus this overall
 	// constant factor should be +- 1 here. Verify this:
 	if ( ! ( fmpz_equal_si(overall_constant.d, 1) || fmpz_equal_si(overall_constant.d, -1) ) ) {
+		// INTERNAL_ERROR_EXCL_START
 		MLOCK(ErrorMessageLock);
-		MesPrint("flint::factorize_mpoly error: overall constant factor != +-1");
+		MesPrint("!>flint::factorize_mpoly error: overall constant factor != +-1");
 		MUNLOCK(ErrorMessageLock);
 		Terminate(-1);
+		// INTERNAL_ERROR_EXCL_STOP
 	}
 
 	// Construct the output. If argout is not NULL, we write the result there.
@@ -389,10 +401,12 @@ WORD* flint::factorize_poly(PHEAD const WORD *argin, WORD *argout, const bool wi
 	flint::from_argument_poly(arg.d, den.d, argin, with_arghead);
 	// The denominator must be 1:
 	if ( fmpz_poly_is_one(den.d) != 1 ) {
+		// INTERNAL_ERROR_EXCL_START
 		MLOCK(ErrorMessageLock);
-		MesPrint("flint::factorize_poly error: den != 1");
+		MesPrint("!>flint::factorize_poly error: den != 1");
 		MUNLOCK(ErrorMessageLock);
 		Terminate(-1);
+		// INTERNAL_ERROR_EXCL_STOP
 	}
 
 
@@ -512,11 +526,13 @@ void flint::form_sort(PHEAD WORD *terms) {
 
 	// Check the final size
 	if ( in_size != out_size  ) {
+		// INTERNAL_ERROR_EXCL_START
 		MLOCK(ErrorMessageLock);
-		MesPrint("flint::form_sort: error: unexpected sorted arg length change %d->%d", in_size,
+		MesPrint("!>flint::form_sort: error: unexpected sorted arg length change %d->%d", in_size,
 			out_size);
 		MUNLOCK(ErrorMessageLock);
 		Terminate(-1);
+		// INTERNAL_ERROR_EXCL_STOP
 	}
 
 	AR.SortType = oldsorttype;
@@ -949,16 +965,20 @@ WORD* flint::gcd_mpoly(PHEAD const WORD *a, const WORD *b, const WORD must_fit_t
 
 	// denpa, denpb must be 1:
 	if ( fmpz_mpoly_is_one(denpa.d, ctx.d) != 1 ) {
+		// INTERNAL_ERROR_EXCL_START
 		MLOCK(ErrorMessageLock);
-		MesPrint("flint::gcd_mpoly: error: denpa != 1");
+		MesPrint("!>flint::gcd_mpoly: error: denpa != 1");
 		MUNLOCK(ErrorMessageLock);
 		Terminate(-1);
+		// INTERNAL_ERROR_EXCL_STOP
 	}
 	if ( fmpz_mpoly_is_one(denpb.d, ctx.d) != 1 ) {
+		// INTERNAL_ERROR_EXCL_START
 		MLOCK(ErrorMessageLock);
-		MesPrint("flint::gcd_mpoly: error: denpb != 1");
+		MesPrint("!>flint::gcd_mpoly: error: denpb != 1");
 		MUNLOCK(ErrorMessageLock);
 		Terminate(-1);
+		// INTERNAL_ERROR_EXCL_STOP
 	}
 
 	// poly returns pa if pa == pb, regardless of the lcoeff sign
@@ -973,17 +993,21 @@ WORD* flint::gcd_mpoly(PHEAD const WORD *a, const WORD *b, const WORD must_fit_t
 		flint::mpoly tmp(ctx.d);
 		fmpz_mpoly_term_content(tmp.d, pa.d, ctx.d);
 		if ( fmpz_mpoly_is_one(tmp.d, ctx.d) != 1 ) {
+			// INTERNAL_ERROR_EXCL_START
 			MLOCK(ErrorMessageLock);
-			MesPrint("flint::gcd_mpoly: error: content of 1st arg != 1");
+			MesPrint("!>flint::gcd_mpoly: error: content of 1st arg != 1");
 			MUNLOCK(ErrorMessageLock);
 			Terminate(-1);
+			// INTERNAL_ERROR_EXCL_STOP
 		}
 		fmpz_mpoly_term_content(tmp.d, pb.d, ctx.d);
 		if ( fmpz_mpoly_is_one(tmp.d, ctx.d) != 1 ) {
+			// INTERNAL_ERROR_EXCL_START
 			MLOCK(ErrorMessageLock);
-			MesPrint("flint::gcd_mpoly: error: content of 2nd arg != 1");
+			MesPrint("!>flint::gcd_mpoly: error: content of 2nd arg != 1");
 			MUNLOCK(ErrorMessageLock);
 			Terminate(-1);
+			// INTERNAL_ERROR_EXCL_STOP
 		}
 
 		// The poly class now divides the content out of a,b so that they have a positive lcoeff.
@@ -1044,16 +1068,20 @@ WORD* flint::gcd_poly(PHEAD const WORD *a, const WORD *b, const WORD must_fit_te
 
 	// denpa, denpb must be 1:
 	if ( fmpz_poly_is_one(denpa.d) != 1 ) {
+		// INTERNAL_ERROR_EXCL_START
 		MLOCK(ErrorMessageLock);
-		MesPrint("flint::gcd_poly: error: denpa != 1");
+		MesPrint("!>flint::gcd_poly: error: denpa != 1");
 		MUNLOCK(ErrorMessageLock);
 		Terminate(-1);
+		// INTERNAL_ERROR_EXCL_STOP
 	}
 	if ( fmpz_poly_is_one(denpb.d) != 1 ) {
+		// INTERNAL_ERROR_EXCL_START
 		MLOCK(ErrorMessageLock);
-		MesPrint("flint::gcd_poly: error: denpb != 1");
+		MesPrint("!>flint::gcd_poly: error: denpb != 1");
 		MUNLOCK(ErrorMessageLock);
 		Terminate(-1);
+		// INTERNAL_ERROR_EXCL_STOP
 	}
 
 	// poly returns pa if pa == pb, regardless of the lcoeff sign
@@ -1067,17 +1095,21 @@ WORD* flint::gcd_poly(PHEAD const WORD *a, const WORD *b, const WORD must_fit_te
 		flint::fmpz tmp;
 		fmpz_poly_content(tmp.d, pa.d);
 		if ( fmpz_is_one(tmp.d) != 1 ) {
+			// INTERNAL_ERROR_EXCL_START
 			MLOCK(ErrorMessageLock);
-			MesPrint("flint::gcd_poly: error: content of 1st arg != 1");
+			MesPrint("!>flint::gcd_poly: error: content of 1st arg != 1");
 			MUNLOCK(ErrorMessageLock);
 			Terminate(-1);
+			// INTERNAL_ERROR_EXCL_STOP
 		}
 		fmpz_poly_content(tmp.d, pb.d);
 		if ( fmpz_is_one(tmp.d) != 1 ) {
+			// INTERNAL_ERROR_EXCL_START
 			MLOCK(ErrorMessageLock);
-			MesPrint("flint::gcd_poly: error: content of 2nd arg != 1");
+			MesPrint("!>flint::gcd_poly: error: content of 2nd arg != 1");
 			MUNLOCK(ErrorMessageLock);
 			Terminate(-1);
+			// INTERNAL_ERROR_EXCL_STOP
 		}
 
 		fmpz_poly_gcd(gcd.d, pa.d, pb.d);
@@ -1325,16 +1357,20 @@ WORD* flint::mul_mpoly(PHEAD const WORD *a, const WORD *b, const var_map_t &var_
 
 	// denpa, denpb must be integers. Negative symbol powers have been converted to extra symbols.
 	if ( fmpz_mpoly_is_fmpz(denpa.d, ctx.d) != 1 ) {
+		// INTERNAL_ERROR_EXCL_START
 		MLOCK(ErrorMessageLock);
-		MesPrint("flint::mul_mpoly: error: denpa is non-constant");
+		MesPrint("!>flint::mul_mpoly: error: denpa is non-constant");
 		MUNLOCK(ErrorMessageLock);
 		Terminate(-1);
+		// INTERNAL_ERROR_EXCL_STOP
 	}
 	if ( fmpz_mpoly_is_fmpz(denpb.d, ctx.d) != 1 ) {
+		// INTERNAL_ERROR_EXCL_START
 		MLOCK(ErrorMessageLock);
-		MesPrint("flint::mul_mpoly: error: denpb is non-constant");
+		MesPrint("!>flint::mul_mpoly: error: denpb is non-constant");
 		MUNLOCK(ErrorMessageLock);
 		Terminate(-1);
+		// INTERNAL_ERROR_EXCL_STOP
 	}
 
 	// Multiply numerators, store result in pa
@@ -1376,16 +1412,20 @@ WORD* flint::mul_poly(PHEAD const WORD *a, const WORD *b, const var_map_t &var_m
 
 	// denpa, denpb must be integers. Negative symbol powers have been converted to extra symbols.
 	if ( fmpz_poly_degree(denpa.d) != 0 ) {
+		// INTERNAL_ERROR_EXCL_START
 		MLOCK(ErrorMessageLock);
-		MesPrint("flint::mul_poly: error: denpa is non-constant");
+		MesPrint("!>flint::mul_poly: error: denpa is non-constant");
 		MUNLOCK(ErrorMessageLock);
 		Terminate(-1);
+		// INTERNAL_ERROR_EXCL_STOP
 	}
 	if ( fmpz_poly_degree(denpb.d) != 0 ) {
+		// INTERNAL_ERROR_EXCL_START
 		MLOCK(ErrorMessageLock);
-		MesPrint("flint::mul_poly: error: denpb is non-constant");
+		MesPrint("!>flint::mul_poly: error: denpb is non-constant");
 		MUNLOCK(ErrorMessageLock);
 		Terminate(-1);
+		// INTERNAL_ERROR_EXCL_STOP
 	}
 
 	// Multiply numerators, store result in pa

--- a/sources/float.c
+++ b/sources/float.c
@@ -173,7 +173,7 @@ void RatToFloat(mpf_t result, UWORD *formrat, int ratsize);
  		#] Explanations : 
  		#[ Form_mpf_init :
 */
-
+/* UNFINISHED_FEATURE_EXCL_START */
 void Form_mpf_init(mpf_t t)
 {
 	mp_limb_t *d;
@@ -192,12 +192,12 @@ void Form_mpf_init(mpf_t t)
 	t->_mp_d = d;
 	for ( i = 0; i < prec; i++ ) d[i] = 0;
 }
-
+/* UNFINISHED_FEATURE_EXCL_STOP */
 /*
  		#] Form_mpf_init : 
  		#[ Form_mpf_clear :
 */
-
+/* UNFINISHED_FEATURE_EXCL_START */
 void Form_mpf_clear(mpf_t t)
 {
 	if ( t->_mp_d ) { M_free(t->_mp_d,"Form_mpf_init"); t->_mp_d = 0; }
@@ -205,7 +205,7 @@ void Form_mpf_clear(mpf_t t)
 	t->_mp_size = 0;
 	t->_mp_exp = 0;
 }
-
+/* UNFINISHED_FEATURE_EXCL_STOP */
 /*
  		#] Form_mpf_clear : 
  		#[ Form_mpf_empty :
@@ -223,7 +223,7 @@ void Form_mpf_empty(mpf_t t)
  		#] Form_mpf_empty : 
  		#[ Form_mpf_set_prec_raw :
 */
-
+/* UNFINISHED_FEATURE_EXCL_START */
 void Form_mpf_set_prec_raw(mpf_t t,ULONG newprec)
 {
 	ULONG newpr = (newprec + 8*sizeof(mp_limb_t)-1)/(8*sizeof(mp_limb_t)) + 1;
@@ -247,7 +247,7 @@ void Form_mpf_set_prec_raw(mpf_t t,ULONG newprec)
 		Terminate(-1);
 	}
 }
-
+/* UNFINISHED_FEATURE_EXCL_STOP */
 /*
  		#] Form_mpf_set_prec_raw : 
  		#[ PackFloat :
@@ -642,7 +642,7 @@ void RatToFloat(mpf_t result, UWORD *formrat, int ratsize)
  		#] RatToFloat : 
  		#[ FloatFunToRat :
 */
-
+/* UNFINISHED_FEATURE_EXCL_START */
 WORD FloatFunToRat(PHEAD UWORD *ratout,WORD *in)
 {
 	WORD oldin = in[0], nratout;
@@ -652,7 +652,7 @@ WORD FloatFunToRat(PHEAD UWORD *ratout,WORD *in)
 	in[0] = oldin;
 	return(nratout);
 }
-
+/* UNFINISHED_FEATURE_EXCL_STOP */
 /*
  		#] FloatFunToRat : 
  		#[ FloatToRat :
@@ -991,7 +991,7 @@ int PrintFloat(WORD *fun,int numdigits)
  		#] PrintFloat : 
  		#[ AddFloats :
 */
-
+/* UNFINISHED_FEATURE_EXCL_START */
 int AddFloats(PHEAD WORD *fun3, WORD *fun1, WORD *fun2)
 {
 	int retval = 0;
@@ -1002,12 +1002,12 @@ int AddFloats(PHEAD WORD *fun3, WORD *fun1, WORD *fun2)
 	else { retval = -1; }
 	return(retval);
 }
-
+/* UNFINISHED_FEATURE_EXCL_STOP */
 /*
  		#] AddFloats : 
  		#[ MulFloats :
 */
-
+/* UNFINISHED_FEATURE_EXCL_START */
 int MulFloats(PHEAD WORD *fun3, WORD *fun1, WORD *fun2)
 {
 	int retval = 0;
@@ -1018,12 +1018,12 @@ int MulFloats(PHEAD WORD *fun3, WORD *fun1, WORD *fun2)
 	else { retval = -1; }
 	return(retval);
 }
-
+/* UNFINISHED_FEATURE_EXCL_STOP */
 /*
  		#] MulFloats : 
  		#[ DivFloats :
 */
-
+/* UNFINISHED_FEATURE_EXCL_START */
 int DivFloats(PHEAD WORD *fun3, WORD *fun1, WORD *fun2)
 {
 	int retval = 0;
@@ -1034,14 +1034,14 @@ int DivFloats(PHEAD WORD *fun3, WORD *fun1, WORD *fun2)
 	else { retval = -1; }
 	return(retval);
 }
-
+/* UNFINISHED_FEATURE_EXCL_STOP */
 /*
  		#] DivFloats : 
  		#[ AddRatToFloat :
 
 		Note: this can be optimized, because often the rat is rather simple.
 */
-
+/* UNFINISHED_FEATURE_EXCL_START */
 int AddRatToFloat(PHEAD WORD *outfun, WORD *infun, UWORD *formrat, WORD nrat)
 {
 	int retval = 0;
@@ -1053,14 +1053,14 @@ int AddRatToFloat(PHEAD WORD *outfun, WORD *infun, UWORD *formrat, WORD nrat)
 	else retval = -1;
 	return(retval);
 }
-
+/* UNFINISHED_FEATURE_EXCL_STOP */
 /*
  		#] AddRatToFloat : 
  		#[ MulRatToFloat :
 
 		Note: this can be optimized, because often the rat is rather simple.
 */
-
+/* UNFINISHED_FEATURE_EXCL_START */
 int MulRatToFloat(PHEAD WORD *outfun, WORD *infun, UWORD *formrat, WORD nrat)
 {
 	int retval = 0;
@@ -1072,7 +1072,7 @@ int MulRatToFloat(PHEAD WORD *outfun, WORD *infun, UWORD *formrat, WORD nrat)
 	else retval = -1;
 	return(retval);
 }
-
+/* UNFINISHED_FEATURE_EXCL_STOP */
 /*
  		#] MulRatToFloat : 
  		#[ SetupMZVTables :
@@ -1681,11 +1681,13 @@ int AddWithFloat(PHEAD WORD **ps1, WORD **ps2)
 		if ( size2 < 0 ) mpf_neg(aux2,aux2);
 	}
 	else {
+/* INTERNAL_ERROR_EXCL_START */
 		MLOCK(ErrorMessageLock);
-		MesPrint("Illegal value %d for AT.SortFloatMode in AddWithFloat.",AT.SortFloatMode);
+		MesPrint("!>Illegal value %d for AT.SortFloatMode in AddWithFloat.",AT.SortFloatMode);
 		MUNLOCK(ErrorMessageLock);
 		Terminate(-1);
 		return(0);
+/* INTERNAL_ERROR_EXCL_STOP */
 	}
 	mpf_add(aux3,aux1,aux2);
 	sign3 = mpf_sgn(aux3);
@@ -1798,11 +1800,13 @@ int MergeWithFloat(PHEAD WORD **interm1, WORD **interm2)
 		if ( size2 < 0 ) mpf_neg(aux2,aux2);
 	}
 	else {
+/* INTERNAL_ERROR_EXCL_START */
 		MLOCK(ErrorMessageLock);
-		MesPrint("Illegal value %d for AT.SortFloatMode in MergeWithFloat.",AT.SortFloatMode);
+		MesPrint("!>Illegal value %d for AT.SortFloatMode in MergeWithFloat.",AT.SortFloatMode);
 		MUNLOCK(ErrorMessageLock);
 		Terminate(-1);
 		return(0);
+/* INTERNAL_ERROR_EXCL_STOP */
 	}
 	mpf_add(aux3,aux1,aux2);
 	sign3 = mpf_sgn(aux3);
@@ -2018,10 +2022,12 @@ void SingleTable(mpf_t *tabl, int N, int m, int pow)
 	mpf_t jm,jjm;
 	mpf_init(jm); mpf_init(jjm);
 	if ( pow < 1 || pow > 2 ) {
+/* INTERNAL_ERROR_EXCL_START */
 		MLOCK(ErrorMessageLock);
-		MesPrint("Wrong parameter pow in SingleTable: %d\n",pow);
+		MesPrint("!>Wrong parameter pow in SingleTable: %d\n",pow);
 		MUNLOCK(ErrorMessageLock);
 		Terminate(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 	}
 	if ( m < 0 ) { m = -m; s = -1; }
 	mpf_set_si(auxsum,0L);
@@ -2061,10 +2067,12 @@ void DoubleTable(mpf_t *tabout, mpf_t *tabin, int N, int m, int pow)
 	mpf_t jm,jjm;
 	mpf_init(jm); mpf_init(jjm);
 	if ( pow < -1 || pow > 2 ) {
+/* INTERNAL_ERROR_EXCL_START */
 		MLOCK(ErrorMessageLock);
-		MesPrint("Wrong parameter pow in DoubleTable: %d\n",pow);
+		MesPrint("!>Wrong parameter pow in DoubleTable: %d\n",pow);
 		MUNLOCK(ErrorMessageLock);
 		Terminate(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 	}
 	if ( m < 0 ) { m = -m; s = -1; }
 	mpf_set_ui(auxsum,0L);
@@ -2113,10 +2121,12 @@ void EndTable(mpf_t sum, mpf_t *tabin, int N, int m, int pow)
 	mpf_t jm,jjm;
 	mpf_init(jm); mpf_init(jjm);
 	if ( pow < -1 || pow > 2 ) {
+/* INTERNAL_ERROR_EXCL_START */
 		MLOCK(ErrorMessageLock);
-		MesPrint("Wrong parameter pow in EndTable: %d\n",pow);
+		MesPrint("!>Wrong parameter pow in EndTable: %d\n",pow);
 		MUNLOCK(ErrorMessageLock);
 		Terminate(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 	}
 	if ( m < 0 ) { m = -m; s = -1; }
 	mpf_set_si(sum,0L);
@@ -2526,26 +2536,26 @@ void CalculateEuler(mpf_t result, WORD *Zindexes, int depth)
  		#] CalculateEuler : 
  		#[ ExpandMZV :
 */
-
+/* UNFINISHED_FEATURE_EXCL_START */
 int ExpandMZV(WORD *term, WORD level)
 {
 	DUMMYUSE(term);
 	DUMMYUSE(level);
 	return(0);
 }
-
+/* UNFINISHED_FEATURE_EXCL_STOP */
 /*
  		#] ExpandMZV : 
  		#[ ExpandEuler :
 */
-
+/* UNFINISHED_FEATURE_EXCL_START */
 int ExpandEuler(WORD *term, WORD level)
 {
 	DUMMYUSE(term);
 	DUMMYUSE(level);
 	return(0);
 }
-
+/* UNFINISHED_FEATURE_EXCL_STOP */
 /*
  		#] ExpandEuler : 
  		#[ EvaluateEuler :

--- a/sources/if.c
+++ b/sources/if.c
@@ -407,6 +407,7 @@ int DoIfStatement(PHEAD WORD *ifcode, WORD *term)
 				for ( i = 0; i < j; i++ ) coef2[i] = cc[i];
 				break;
 #ifdef WITHFLOAT
+/* UNFINISHED_FEATURE_EXCL_START */
 			case IFFLOATNUMBER:
 /*
 				The sloppy solution is: Convert to rational.
@@ -414,6 +415,7 @@ int DoIfStatement(PHEAD WORD *ifcode, WORD *term)
 */
 				ncoef2 = FloatFunToRat(BHEAD coef2,ifp);
 				break;
+/* UNFINISHED_FEATURE_EXCL_STOP */
 #endif
 			case MATCH:
 			case TYPEIF:

--- a/sources/message.c
+++ b/sources/message.c
@@ -124,6 +124,7 @@ NORETURN void MesWork(void)
 	#   " ==> "
 	@   " ==> "   Preprocessor error
 	&   ' --> '   Regular compiler error
+	!>  ' ~~> '   Internal error
 	Each call is terminated with a new line.
 	Put a % at the end of the string to suppress the new line.
 
@@ -172,7 +173,7 @@ int MesPrint(const char *fmt, ... )
 	t = Out;
 	stopper = Out + AC.LineLength;
 	while ( *s ) {
-		if ( ( ( *s == '&' && AO.ErrorBlock == 0 ) || *s == '@' || *s == '#' ) && AC.CurrentStream != 0 ) {
+		if ( ( *s == '&' || *s == '@' || *s == '#' || ( *s == '!' && s[1] == '>' ) ) && AO.ErrorBlock == 0 && AC.CurrentStream != 0 ) {
 			u = (char *)AC.CurrentStream->name;
 			while ( *u ) {
 				*t++ = *u++;
@@ -199,8 +200,23 @@ int MesPrint(const char *fmt, ... )
 		if ( ( *s == '&' && AO.ErrorBlock == 0 ) ) {
 			*t++ = ' '; *t++ = '-'; *t++ = '-'; *t++ = '>'; *t++ = ' '; s++;
 		}
-		else if ( *s == '@' || *s == '#' ) {
+		else if ( ( *s == '@' || *s == '#' ) && AO.ErrorBlock == 0 ) {
 			*t++ = ' '; *t++ = '='; *t++ = '='; *t++ = '>'; *t++ = ' '; s++;
+		}
+		else if ( *s == '!' && s[1] == '>' && AO.ErrorBlock == 0 ) {
+			const char *m = " ~~> Internal error, please report with the following message:";
+			while ( *m ) {
+				*t++ = *m++;
+				if ( t >= stopper ) {
+					num = t - Out;
+					WriteString(ERROROUT,(UBYTE *)Out,num);
+					num = 0; t = Out;
+				}
+			}
+			num = t - Out;
+			WriteString(ERROROUT,(UBYTE *)Out,num);
+			num = 0; t = Out;
+			s += 2;
 		}
 /*
 		else if ( *s == '&' && AO.ErrorBlock == 1 ) {

--- a/sources/names.c
+++ b/sources/names.c
@@ -336,7 +336,7 @@ NotFound:;
 	during runtime. In the case of the $ the value in funnum is -dolnum-1.
 	The return value is the position after the name of the function or the $.
 */
- 
+ /* UNFINISHED_FEATURE_EXCL_START */
 static WORD one = 1;
 
 UBYTE *GetFunction(UBYTE *s,WORD *funnum)
@@ -375,7 +375,7 @@ UBYTE *GetFunction(UBYTE *s,WORD *funnum)
 	*t1 = c;
 	return(t1);
 }
-
+/* UNFINISHED_FEATURE_EXCL_STOP */
 /*
   	#] GetFunction : 
   	#[ GetNumber :
@@ -384,7 +384,7 @@ UBYTE *GetFunction(UBYTE *s,WORD *funnum)
 	during runtime. In the case of the $ the value in num is -dolnum-2.
 	The return value is the position after the number or the $.
 */
-
+/* UNFINISHED_FEATURE_EXCL_START */
 UBYTE *GetNumber(UBYTE *s,WORD *num)
 {
 	int type;
@@ -423,7 +423,7 @@ illegal:
 	*t1 = c;
 	return(t1);
 }
-
+/* UNFINISHED_FEATURE_EXCL_STOP */
 /*
   	#] GetNumber : 
   	#[ GetLastExprName :
@@ -598,7 +598,7 @@ int GetDollar(UBYTE *name)
   	#] GetDollar : 
   	#[ DumpTree :
 */
-
+/* DEBUG_EXCL_START */
 void DumpTree(NAMETREE *nametree)
 {
 	if ( nametree->headnode >= 0
@@ -606,12 +606,12 @@ void DumpTree(NAMETREE *nametree)
 		DumpNode(nametree,nametree->headnode,0);
 	}
 }
-
+/* DEBUG_EXCL_STOP */
 /*
   	#] DumpTree : 
   	#[ DumpNode :
 */
-
+/* DEBUG_EXCL_START */
 void DumpNode(NAMETREE *nametree, WORD node, WORD depth)
 {
 	NAMENODE *n;
@@ -625,7 +625,7 @@ void DumpNode(NAMETREE *nametree, WORD node, WORD depth)
 		name,node,n->parent,n->left,n->right,n->balance);
 	if ( n->right >= 0 ) DumpNode(nametree,n->right,depth+1);
 }
-
+/* DEBUG_EXCL_STOP */
 /*
   	#] DumpNode : 
   	#[ CompactifyTree :
@@ -830,7 +830,7 @@ NAMETREE *MakeNameTree(void)
   	#] MakeNameTree : 
   	#[ FreeNameTree :
 */
-
+/* UNFINISHED_FEATURE_EXCL_START */
 void FreeNameTree(NAMETREE *n)
 {
 	if ( n ) {
@@ -839,7 +839,7 @@ void FreeNameTree(NAMETREE *n)
 		M_free(n,"nametree");
 	}
 }
-
+/* UNFINISHED_FEATURE_EXCL_STOP */
 /*
   	#] FreeNameTree : 
 
@@ -2361,6 +2361,7 @@ int CoSet(UBYTE *s)
 	SETS set;
 	WORD numberofset, dim = MAXPOSITIVE;
 #ifdef WITHFLOAT
+/* UNFINISHED_FEATURE_EXCL_START */
 /*----------------------------------------------------------------*/
 	{
 		WORD numeq = 0;
@@ -2391,6 +2392,7 @@ Proper:
 		}		
 	}
 /*----------------------------------------------------------------*/
+/* UNFINISHED_FEATURE_EXCL_STOP */
 #endif
 	if ( ( s = SkipAName(s) ) == 0 ) {
 IllForm:MesPrint("&Illegal name for set");
@@ -2643,7 +2645,7 @@ int AddDollar(UBYTE *name, WORD type, WORD *start, LONG size)
 
 	Not in use????
 */
-
+/* UNFINISHED_FEATURE_EXCL_START */
 int ReplaceDollar(WORD number, WORD newtype, WORD *newstart, LONG newsize)
 {
 	int error = 0;
@@ -2669,7 +2671,7 @@ int ReplaceDollar(WORD number, WORD newtype, WORD *newstart, LONG newsize)
 	}
 	return(error);
 }
-
+/* UNFINISHED_FEATURE_EXCL_STOP */
 /*
   	#] ReplaceDollar : 
   	#[ AddDubious :

--- a/sources/pre.c
+++ b/sources/pre.c
@@ -7317,7 +7317,7 @@ int DoTimeOutAfter(UBYTE *s)
 			Names of preprocessor variables are excluded!
 			Names of built in objects are excluded! (like sum_, d_ etc.)
 */
-
+/* UNFINISHED_FEATURE_EXCL_START */
 int DoNamespace(UBYTE *s)
 {
 	UBYTE *s1, *s2, c;
@@ -7360,12 +7360,12 @@ int DoNamespace(UBYTE *s)
 	*s1 = c;
 	return(0);
 }
-
+/* UNFINISHED_FEATURE_EXCL_STOP */
 /*
  		#] DoNamespace : 
  		#[ DoEndNamespace :
 */
-
+/* UNFINISHED_FEATURE_EXCL_START */
 int DoEndNamespace(UBYTE *s)
 {
 	NAMESPACE *namespace;
@@ -7383,7 +7383,7 @@ int DoEndNamespace(UBYTE *s)
 	M_free(namespace,"namespace");
 	return(0);
 }
-
+/* UNFINISHED_FEATURE_EXCL_STOP */
 /*
  		#] DoEndNamespace : 
  		#[ SkipName :
@@ -7580,7 +7580,7 @@ UBYTE *ConstructName(UBYTE *s,UBYTE type)
 		The names are stored in a balanced tree. Each namespace may have
 		its own tree. The toplevel (no namespace) does not allow a #use.
 */
-
+/* UNFINISHED_FEATURE_EXCL_START */
 int DoUse(UBYTE *s)
 {
 	NAMESPACE *namespace;
@@ -7612,7 +7612,7 @@ int DoUse(UBYTE *s)
 	}
 	return(0);
 }
-
+/* UNFINISHED_FEATURE_EXCL_STOP */
 /*
  		#] DoUse : 
  		#[ UserFlags :
@@ -7628,7 +7628,7 @@ int DoUse(UBYTE *s)
 		#SetFlag
 		par == 0: Clear, par == 1: Set.
 */
-
+/* UNFINISHED_FEATURE_EXCL_START */
 int UserFlags(UBYTE *s,int par)
 {
 	int mask = 0, error = 0, i;
@@ -7730,27 +7730,27 @@ syntax:
 	MesPrint("@Illegal name in #...Flag instruction.");
 	return(1);
 }
-
+/* UNFINISHED_FEATURE_EXCL_STOP */
 /*
  		#] UserFlags : 
  		#[ DoClearUserFlag :
 */
-
+/* UNFINISHED_FEATURE_EXCL_START */
 int DoClearUserFlag(UBYTE *s)
 {
 	return(UserFlags(s,0));
 }
-
+/* UNFINISHED_FEATURE_EXCL_STOP */
 /*
  		#] DoClearUserFlag : 
  		#[ DoSetUserFlag :
 */
-
+/* UNFINISHED_FEATURE_EXCL_START */
 int DoSetUserFlag(UBYTE *s)
 {
 	return(UserFlags(s,1));
 }
-
+/* UNFINISHED_FEATURE_EXCL_STOP */
 /*
  		#] DoSetUserFlag : 
  		#[ DoStartFloat :

--- a/sources/proces.c
+++ b/sources/proces.c
@@ -4236,9 +4236,11 @@ AutoGen:	i = *AT.TMout;
 #ifdef WITHPTHREADS
 				if ( dtype > 0 && ! DollarLocalCopy(dtype) ) { UNLOCK(d->pthreadslock); }
 				if ( ( AS.Balancing && CC->numrhs == 0 ) && StartBuf[posisub] ) {
+/* UNFINISHED_FEATURE_EXCL_START */
 					if ( ( id = ConditionalGetAvailableThread() ) >= 0 ) {
 						if ( BalanceRunThread(BHEAD id,termout,level) < 0 ) goto GenCall;
 					}
+/* UNFINISHED_FEATURE_EXCL_STOP */
 				}
 				else
 #endif
@@ -4320,10 +4322,12 @@ AutoGen:	i = *AT.TMout;
 					AR.expchanged = 1;
 #ifdef WITHPTHREADS
 					if ( dtype > 0 && ! DollarLocalCopy(dtype) ) { UNLOCK(d->pthreadslock); }
+/* UNFINISHED_FEATURE_EXCL_START */
 					if ( ( AS.Balancing && CC->numrhs == 0 ) && ( i > 0 )
 					&& ( id = ConditionalGetAvailableThread() ) >= 0 ) {
 						if ( BalanceRunThread(BHEAD id,termout,level) < 0 ) goto GenCall;
 					}
+/* UNFINISHED_FEATURE_EXCL_STOP */
 					else
 #endif
 					if ( Generator(BHEAD termout,level) ) goto GenCall;
@@ -4385,7 +4389,9 @@ AutoGen:	i = *AT.TMout;
 #ifdef WITHPTHREADS
 					if ( dtype > 0 && ! DollarLocalCopy(dtype) ) { UNLOCK(d->pthreadslock); }
 					if ( ( AS.Balancing && CC->numrhs == 0 ) && ( i > 0 ) && ( id = ConditionalGetAvailableThread() ) >= 0 ) {
+/* UNFINISHED_FEATURE_EXCL_START */
 						if ( BalanceRunThread(BHEAD id,termout,level) < 0 ) goto GenCall;
+/* UNFINISHED_FEATURE_EXCL_STOP */
 					}
 					else
 #endif
@@ -4504,8 +4510,9 @@ skippedfirst:
 						AR.expchanged = 1;
 #ifdef WITHPTHREADS
 						if ( ( AS.Balancing && CC->numrhs == 0 ) && ( i > 0 ) && ( id = ConditionalGetAvailableThread() ) >= 0 ) {
+/* UNFINISHED_FEATURE_EXCL_START */
 							if ( BalanceRunThread(BHEAD id,termout,level) < 0 ) goto GenCall;
-
+/* UNFINISHED_FEATURE_EXCL_STOP */
 						}
 						else
 #endif

--- a/sources/threads.c
+++ b/sources/threads.c
@@ -980,6 +980,7 @@ int MakeThreadBuckets(int number, int par)
  *  its size. This is used by the checkpoint code to save this information in
  *  the recovery file.
  */
+/* UNFINISHED_FEATURE_EXCL_START */
 int GetTimerInfo(LONG** ti,LONG** sti)
 {
 	*ti = timerinfo;
@@ -990,7 +991,7 @@ int GetTimerInfo(LONG** ti,LONG** sti)
 	return AM.totalnumberofthreads;
 #endif
 }
-
+/* UNFINISHED_FEATURE_EXCL_STOP */
 /*
   	#] GetTimerInfo : 
   	#[ WriteTimerInfo :
@@ -1000,6 +1001,7 @@ int GetTimerInfo(LONG** ti,LONG** sti)
  *  Writes data into the static timerinfo variable. This is used by the
  *  checkpoint code to restore the correct timings for the individual threads.
  */
+/* UNFINISHED_FEATURE_EXCL_START */
 void WriteTimerInfo(LONG* ti,LONG* sti)
 {
 	int i;
@@ -1013,7 +1015,7 @@ void WriteTimerInfo(LONG* ti,LONG* sti)
 		sumtimerinfo[i] = sti[i];
 	}
 }
-
+/* UNFINISHED_FEATURE_EXCL_STOP */
 /*
   	#] WriteTimerInfo : 
   	#[ GetWorkerTimes :
@@ -1174,7 +1176,7 @@ int LoadOneThread(int from, int identity, THREADBUCKET *thr, int par)
  *	@param level     The level at which we are in the tree. Defines the statement.
  *	@return Standard return convention (OK -> 0)
  */
-
+/* UNFINISHED_FEATURE_EXCL_START */
 int BalanceRunThread(PHEAD int identity, WORD *term, WORD level)
 {
 	GETBIDENTITY
@@ -1204,7 +1206,7 @@ int BalanceRunThread(PHEAD int identity, WORD *term, WORD level)
 
 	return(0);
 }
-
+/* UNFINISHED_FEATURE_EXCL_STOP */
 /*
   	#] BalanceRunThread : 
   	#[ SetWorkerFiles :

--- a/sources/tools.c
+++ b/sources/tools.c
@@ -1021,7 +1021,7 @@ int OpenAddFile(char *name)
  		#] OpenAddFile : 
  		#[ ReOpenFile :
 */
-
+/* UNFINISHED_FEATURE_EXCL_START */
 int ReOpenFile(char *name)
 {
 	FILES *f;
@@ -1036,7 +1036,7 @@ int ReOpenFile(char *name)
 	SeekFile(i,&scrpos,SEEK_SET);
 	return(i);
 }
-
+/* UNFINISHED_FEATURE_EXCL_STOP */
 /*
  		#] ReOpenFile : 
  		#[ CreateFile :
@@ -1100,6 +1100,7 @@ void CloseFile(int handle)
  *  Returns non-zero if an error occurred.
  *	Uses if possible the combined large and small sorting buffers as cache.
  */
+/* UNFINISHED_FEATURE_EXCL_START */
 int CopyFile(char *source, char *dest)
 {
 	#define COPYFILEBUFSIZE 40960L
@@ -1150,7 +1151,7 @@ int CopyFile(char *source, char *dest)
 	}
 	return(0);
 }
-
+/* UNFINISHED_FEATURE_EXCL_STOP */
 /*
  		#] CopyFile : 
  		#[ CreateHandle :
@@ -1744,7 +1745,7 @@ int StrICont(UBYTE *s1, UBYTE *s2)
  		#] StrICont : 
  		#[ CmpArray :
 */
-
+/* UNFINISHED_FEATURE_EXCL_START */
 int CmpArray(WORD *t1, WORD *t2, WORD n)
 {
 	int i,x;
@@ -1753,7 +1754,7 @@ int CmpArray(WORD *t1, WORD *t2, WORD n)
 	}
 	return(0);
 }
-
+/* UNFINISHED_FEATURE_EXCL_STOP */
 /*
  		#] CmpArray : 
  		#[ ConWord :


### PR DESCRIPTION
This PR wraps unfinished features into LCOV_EXCL_START and LCOV_EXCL_STOP to hide them from coverage statistics. At the moment I hid the (unfinished) code for
- `#namespace`,
- `#setflag`,
- `MultiBracket`,
- the complete `diagrams.c` file.

What else could be hidden because it is not active at the moment? For example the code in `checkpoint.c`?