### PR TITLE
Add the stale workflow for issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,29 @@
+name: Close stale issues
+on:
+  schedule:
+    - cron: '30 0 * * *'  # daily
+  workflow_dispatch:
+
+permissions:
+  actions: write
+  issues: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-slim
+    steps:
+      - uses: actions/stale@v10
+        with:
+          days-before-issue-stale: 90
+          days-before-issue-close: 30
+          stale-issue-message: >
+            This issue has been marked as stale after 90 days of inactivity.
+            It will be closed automatically in 30 days unless there is any further activity.
+            If this issue is still relevant, please leave a comment to keep it open.
+          stale-issue-label: stale
+          exempt-issue-labels: bug,documentation,enhancement,help wanted,needs decision
+          exempt-all-issue-milestones: true
+          days-before-pr-stale: -1  # Do not touch PRs.
+          days-before-pr-close: -1
+          remove-pr-stale-when-updated: false
+          operations-per-run: 15  # Keep stale operations low for now.


### PR DESCRIPTION
See https://github.com/form-dev/form/discussions/844 and slide 2 of [Open Issues at FORM 2026](https://indico.nikhef.nl/event/7533/contributions/29451/attachments/11247/17424/open-issues.pdf).

This patch uses [`actions/stale@v10`](https://github.com/actions/stale).

The values of `days-before-issue-stale`, `days-before-issue-close` and `operations-per-run`, as well as the exempt label `needs decision`, may be adjusted.