### PR TITLE
fix: flint: missed overall factor in univariate polynomial factorization

### DIFF
--- a/check/fixes.frm
+++ b/check/fixes.frm
@@ -4817,6 +4817,82 @@ ModuleOption local $dol;
 assert succeeded?
 assert result("test") =~ expr("0")
 *--#] PullReq843_3 :
+*--#[ PullReq860_1 :
+#-
+
+CFunction f;
+Symbol x;
+
+Local test1 = f(-x+2);
+Local test2 = f(-2*x+2);
+Local test3 = f(x-2);
+Local test4 = f(2*x-2);
+.sort
+
+On highfirst;
+FactArg f;
+
+Print;
+.end
+assert succeeded?
+assert result("test1") =~ expr("f(-1,x - 2)")
+assert result("test2") =~ expr("f(-2,x - 1)")
+assert result("test3") =~ expr("f(x - 2)")
+assert result("test4") =~ expr("f(2,x - 1)")
+*--#] PullReq860_1 :
+*--#[ PullReq860_2 :
+#-
+
+CFunction f;
+Symbol x;
+
+Local test1 = f(-x+2);
+Local test2 = f(-2*x+2);
+Local test3 = f(x-2);
+Local test4 = f(2*x-2);
+.sort
+
+*On highfirst;
+FactArg f;
+
+Print;
+.end
+assert succeeded?
+assert result("test1") =~ expr("f(-1, - 2 + x)")
+assert result("test2") =~ expr("f(-2, - 1 + x)")
+assert result("test3") =~ expr("f( - 2 + x)")
+assert result("test4") =~ expr("f(2, - 1 + x)")
+*--#] PullReq860_2 :
+*--#[ PullReq860_3 :
+#-
+
+CFunction f,g,tag;
+Symbol x;
+
+Local test =
+	#do i = -3,3
+	#do j = -3,3
+		+ f(`i'*x+`j')*tag(`i',`j')
+		- g(`i'*x+`j')*tag(`i',`j')
+	#enddo
+	#enddo
+	;
+.sort
+
+On highfirst;
+FactArg f;
+Transform f mulargs(1,last);
+
+* Trigger re-sort of g into highfirst order
+Argument g;
+EndArgument;
+Identify g(x?) = f(x);
+
+Print;
+.end
+assert succeeded?
+assert result("test") =~ expr("0")
+*--#] PullReq860_3 :
 *--#[ Issue808 :
 #do i=0,9
 Global E`i' = `i';

--- a/sources/flintinterface.cc
+++ b/sources/flintinterface.cc
@@ -414,6 +414,17 @@ WORD* flint::factorize_poly(PHEAD const WORD *argin, WORD *argout, const bool wi
 		// Initially 1, for the final trailing 0.
 		uint64_t output_size = 1;
 
+		// If the overall constant is not 1, make an fmpz_poly out of it and include it. Typically
+		// this does not happen: FORM takes out the overall factor. But we do sometimes have this
+		// case, for eg awkward interactions with "On highfirst;" and non-dirty arguments.
+		if ( ! fmpz_is_one(&(arg_fac.d)->c) ) {
+			flint::poly overall_factor;
+			fmpz_poly_set_fmpz(overall_factor.d, &(arg_fac.d)->c);
+			const bool write = false;
+			output_size += (uint64_t)flint::to_argument_poly(BHEAD NULL, with_arghead, is_fun_arg,
+				write, 0, overall_factor.d, var_map);
+		}
+
 		for ( long i = 0; i < num_factors; i++ ) {
 			fmpz_poly_struct* base = (arg_fac.d)->p + i;
 			
@@ -430,6 +441,17 @@ WORD* flint::factorize_poly(PHEAD const WORD *argin, WORD *argout, const bool wi
 	}
 
 	WORD* old_argout = argout;
+
+	// If the overall constant is not 1, make an fmpz_poly out of it and include it. Typically
+	// this does not happen: FORM takes out the overall factor. But we do sometimes have this
+	// case, for eg awkward interactions with "On highfirst;" and non-dirty arguments.
+	if ( ! fmpz_is_one(&(arg_fac.d)->c) ) {
+		flint::poly overall_factor;
+		fmpz_poly_set_fmpz(overall_factor.d, &(arg_fac.d)->c);
+		const bool write = true;
+		argout += (uint64_t)flint::to_argument_poly(BHEAD argout, with_arghead, is_fun_arg, write,
+			argout-old_argout, overall_factor.d, var_map);
+	}
 
 	for ( long i = 0; i < num_factors; i++ ) {
 		fmpz_poly_struct* base = (arg_fac.d)->p + i;


### PR DESCRIPTION
The flint interface assumed that univariate polynomials have no overall factor, when factorizing. This is usually the case, but changing the sort ordering with for eg "On highfirst" combined with non-dirty arguemnts (which are not re-sorted) can produce input for flint with an overall factor.

---

This one is nasty, since merging the flint interface FORM silently gives bad results in this (hopefully not common) scenario.