### PR TITLE
Include composite actions in Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,9 @@ version: 2
 
 updates:
   - package-ecosystem: github-actions
-    directory: /
+    directories:
+      - /
+      - /.github/actions/*
     schedule:
       interval: weekly
     cooldown:


### PR DESCRIPTION
It seems that when only `/` is specified, Dependabot doesn't check `.github/actions/setup-build/action.yml`.