### PR TITLE
release: stop manually updating version fallback info.

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -1,2 +1,31 @@
 SUBDIRS = doxygen manual devref
 dist_man1_MANS = form.1
+
+.PHONY: clean-local update_version_man
+
+clean-local:
+	rm form.1
+
+form.1: update_version_man
+	$(UPDATE_VERSION_MAN)
+
+dist-hook:
+	$(DISTHOOK_VERSION_MAN)
+
+if FIXED_VERSION
+
+UPDATE_VERSION_MAN = \
+	[ -f form.1 ] || $(LN_S) "$(srcdir)/form.1.in" form.1
+
+DISTHOOK_VERSION_MAN = \
+	cp "$(srcdir)/form.1" "$(distdir)/form.1"
+
+else
+
+UPDATE_VERSION_MAN = \
+	$(SHELL) "$(top_srcdir)/scripts/git-version-gen.sh" -C "$(srcdir)" --man --date-format '%Y-%m-%d' -o form.1 && cat "$(srcdir)/form.1.in" >> form.1
+
+DISTHOOK_VERSION_MAN = \
+	$(SHELL) "$(top_srcdir)/scripts/git-version-gen.sh" -C "$(srcdir)" --man --date-format '%Y-%m-%d' -o "$(distdir)/form.1" && cat "$(srcdir)/form.1.in" >> "$(distdir)/form.1"
+
+endif

--- a/doc/form.1.in
+++ b/doc/form.1.in
@@ -1,4 +1,3 @@
-.TH FORM 1 "2026-01-27"
 .SH NAME
 FORM \- Symbolic manipulation system
 .SH SYNOPSIS

--- a/scripts/git-version-gen.sh
+++ b/scripts/git-version-gen.sh
@@ -85,6 +85,9 @@ for a in "$@"; do
     -t|--tex)
       mode=tex
       ;;
+    -m|--man)
+      mode=man
+      ;;
     -s|--shell)
       mode=shell
       ;;
@@ -211,6 +214,11 @@ END
 \def\repominorversion{$minor_version}
 \def\repopatchversion{$patch_version}
 \def\repoversionsuffix{$version_suffix}
+END
+      ;;
+    man)
+      cat <<END
+.TH FORM 1 "$date" "Version $version"
 END
       ;;
     shell)

--- a/sources/form3.h
+++ b/sources/form3.h
@@ -44,14 +44,15 @@
 
 #else  /* HAVE_CONFIG_H */
 
-#define MAJORVERSION 5
-#define MINORVERSION 0
-#define PATCHVERSION 1
+// This information is now only determined by scripts/git-version-gen.sh
+#define MAJORVERSION X
+#define MINORVERSION Y
+#define PATCHVERSION Z
 
 #ifdef __DATE__
 #define PRODUCTIONDATE __DATE__
 #else
-#define PRODUCTIONDATE "24-jun-2026"
+#define PRODUCTIONDATE "DD-MM-YYYY"
 #endif
 
 #undef BETAVERSION


### PR DESCRIPTION
With this commit, rely completely on `git-version-gen.sh` to determine version information and built date. This means the hardcoded "fallback" version information in `sources/form3.h` does not have to be manually updated for a release, triggering the whole CI cycle. The date and version information is also automatically inserted into the man page.

This makes the release procedure as simple as pushing a new tag to the repository, which streamlines things now that we aim to release much more regular patch versions -- whenever a few small features or significant bugfixes are made.