### PR TITLE
fix: improve stats alignment for long expression names

### DIFF
--- a/check/fixes.frm
+++ b/check/fixes.frm
@@ -4525,6 +4525,75 @@ assert stdout =~ exact_pattern(<<'EOF')
 sumpow: 129
 EOF
 *--#] Issue796c : 
+*--#[ Issue833_1 : 
+#-
+#: TermsInSmall 1024
+On fewerstats 256;
+On humanstats;
+Symbol x;
+Local abcdefghijklmno   = <x^1>+...+<x^15>;
+Local abcdefghijklmnop  = <x^1>+...+<x^16>;
+Local abcdefghijklmnopq = <x^1>+...+<x^17>;
+Local abcdefghijklmnopqrstuvwx = <x^1>+...+<x^24>;
+Local abcdefghijklmnopqrstuvwxy = <x^1>+...+<x^25>;
+Local abcdefghijklmnopqrstuvwxyz = <x^1>+...+<x^26>;
+Local abcdefghijklmnopqrstuvwxyz = <x^1>+...+<x^26>;
+Local abcdefghijklmnopqrstuvwxyzaaaaaaaa = <x^1>+...+<x^34>;
+Local abcdefghijklmnopqrstuvwxyzaaaaaaab = <x^1>+...+<x^340>;
+Local abcdefghijklmnopqrstuvwxyzaaaa = <x^1>+...+<x^262144>;
+Local abcdefghijklmnopqr = <x^1>+...+<x^262144>;
+.sort
+.end
+#require wordsize == 4
+#pend_if mpi? || threaded?
+assert succeeded?
+assert stdout =~ exact_pattern(" abcdefghijklmno         Terms in output =         15  ( <1 K  )")
+assert stdout =~ exact_pattern("abcdefghijklmnop         Terms in output =         16  ( <1 K  )")
+assert stdout =~ exact_pattern("abcdefghijklmnopq        Terms in output =         17  ( <1 K  )")
+assert stdout =~ exact_pattern("abcdefghijklmnopqrstuvwx Terms in output =         24  ( <1 K  )")
+assert stdout =~ exact_pattern("abcdefghijklmnopqrstuvwxy Terms in output=         25  ( <1 K  )")
+assert stdout =~ exact_pattern("abcdefghijklmnopqrstuvwxyz Terms in output=        26  ( <1 K  )")
+assert stdout =~ exact_pattern("abcdefghijklmnopqrstuvwxyzaaaaaaaa Terms in output=34  ( <1 K  )")
+assert stdout =~ exact_pattern("abcdefghijklmnopqrstuvwxyzaaaaaaab Terms in output=340  ( <1 K  )")
+assert stdout =~ exact_pattern("abcdefghijklmnopqrstuvwxyzaaaa Terms in output=262144  (262 K  )")
+assert stdout =~ exact_pattern("abcdefghijklmnopqr       Terms in output =     262144  (262 K  )")
+assert stdout =~ exact_pattern("abcdefghijklmnopqrstuvwxyzaaaa 1 Terms left=   262144  (262 K  )")
+assert stdout =~ exact_pattern("abcdefghijklmnopqrstuvwxyzaaaa 262144 Terms left=262144  (262 K  )")
+assert stdout =~ exact_pattern("abcdefghijklmnopqr     1 Terms left      =     262144  (262 K  )")
+assert stdout =~ exact_pattern("abcdefghijklmnopqr 262144 Terms left     =     262144  (262 K  )")
+*--#] Issue833_1 : 
+*--#[ Issue833_2 : 
+#-
+#: TermsInSmall 1024
+On fewerstats 256;
+On humanstats;
+Symbol x;
+Local abcdefghijklmno   = <x^1>+...+<x^15>;
+Local abcdefghijklmnop  = <x^1>+...+<x^16>;
+Local abcdefghijklmnopq = <x^1>+...+<x^17>;
+Local abcdefghijklmnopqrstuvwx = <x^1>+...+<x^24>;
+Local abcdefghijklmnopqrstuvwxy = <x^1>+...+<x^25>;
+Local abcdefghijklmnopqrstuvwxyz = <x^1>+...+<x^26>;
+Local abcdefghijklmnopqrstuvwxyz = <x^1>+...+<x^26>;
+Local abcdefghijklmnopqrstuvwxyzaaaaaaaa = <x^1>+...+<x^34>;
+Local abcdefghijklmnopqrstuvwxyzaaaaaaab = <x^1>+...+<x^340>;
+Local abcdefghijklmnopqrstuvwxyzaaaa = <x^1>+...+<x^262144>;
+Local abcdefghijklmnopqr = <x^1>+...+<x^262144>;
+.sort
+.end
+#require threaded? && wordsize == 4
+assert succeeded?
+assert stdout =~ exact_pattern(" abcdefghijklmno         Terms in output =         15  ( <1 K  )")
+assert stdout =~ exact_pattern("abcdefghijklmnop         Terms in output =         16  ( <1 K  )")
+assert stdout =~ exact_pattern("abcdefghijklmnopq        Terms in output =         17  ( <1 K  )")
+assert stdout =~ exact_pattern("abcdefghijklmnopqrstuvwx Terms in output =         24  ( <1 K  )")
+assert stdout =~ exact_pattern("abcdefghijklmnopqrstuvwxy Terms in output=         25  ( <1 K  )")
+assert stdout =~ exact_pattern("abcdefghijklmnopqrstuvwxyz Terms in output=        26  ( <1 K  )")
+assert stdout =~ exact_pattern("abcdefghijklmnopqrstuvwxyzaaaaaaaa Terms in output=34  ( <1 K  )")
+assert stdout =~ exact_pattern("abcdefghijklmnopqrstuvwxyzaaaaaaab Terms in output=340  ( <1 K  )")
+assert stdout =~ exact_pattern("abcdefghijklmnopqrstuvwxyzaaaa Terms in output=262144  (262 K  )")
+assert stdout =~ exact_pattern("abcdefghijklmnopqr       Terms in output =     262144  (262 K  )")
+*--#] Issue833_2 : 
 *--#[ PullReq535 :
 * This test requires more than the specified 50K workspace.
 #:maxtermsize 200

--- a/sources/inivar.h
+++ b/sources/inivar.h
@@ -84,8 +84,8 @@ FIXEDGLOBALS FG = {
 		,{" Functions"
 		," Commuting Functions"}
 
-		,{"left     "
-		,"active   "
+		,{"left"
+		,"active"
 		,"in output"}
 
 	,(char *)0

--- a/sources/sort.c
+++ b/sources/sort.c
@@ -100,6 +100,11 @@ void HumanString(char* string, float input, const char suffix[HUMANSUFFLEN][4]) 
 	}
 }
 
+#define COL_EXP 16
+#define COL_SPA 8
+#define COL_EQU 42
+#define COL_VAL 53
+
 WORD DigitsIn(LONG x) {
 	if ( x < 0 ) x = -x;
 	WORD dig = 1;
@@ -265,65 +270,89 @@ void WriteStats(POSITION *plspace, WORD par, WORD checkLogType)
 			}
 			else {
 				snprintf(buf, sizeof(buf),
-					"%sTime = %7ld.%02u sec   %sGenerated terms = %10ld%s",
-					wpref,millitime,timepart,wspac,S->GenTerms,humanGenTermsText);
+					"%sTime = %7ld.%02u sec   %sGenerated terms =%11ld%s",
+					wpref, millitime, timepart, wspac, S->GenTerms, humanGenTermsText);
 				MesPrint("%s", buf);
 			}
 
+			const int exprlen = strlen((char*)EXPRNAME(AR.CurExpr));
+			const int overflow = MaX(0, exprlen - COL_EXP);
 			if ( par == STATSSPLITMERGE ) {
-				snprintf(buf, sizeof(buf),
-					"%16s%8ld Terms %s = %10ld%s",
-					EXPRNAME(AR.CurExpr),AN.ninterms,FG.swmes[par],S->TermsLeft,
-					humanTermsLeftText);
+				int width = snprintf(buf, sizeof(buf),
+					"%*s %*ld Terms %s",
+					COL_EXP, EXPRNAME(AR.CurExpr),
+					MaX(0,COL_SPA-1-overflow), AN.ninterms, FG.swmes[par]);
+				width += snprintf(buf+width, sizeof(buf)-width,
+					"%*s=",
+					MaX(0,COL_EQU-1-width), "");
+				snprintf(buf+width, sizeof(buf)-width,
+					"%*ld%s",
+					MaX(0,COL_VAL-width), S->TermsLeft, humanTermsLeftText);
 				MesPrint("%s", buf);
 			}
 			else {
 #ifdef WITHPTHREADS
 				if ( identity > 0 && par == STATSPOSTSORT ) {
-					snprintf(buf, sizeof(buf),
-						"%16s         Terms in thread = %10ld%s",
-						EXPRNAME(AR.CurExpr),S->TermsLeft,humanTermsLeftText);
+					int width = snprintf(buf, sizeof(buf),
+						"%*s%*s Terms in thread",
+						COL_EXP, EXPRNAME(AR.CurExpr), MaX(0,COL_SPA-overflow), "");
+					width += snprintf(buf+width, sizeof(buf)-width,
+						"%*s=",
+						MaX(0,COL_EQU-1-width), "");
+					snprintf(buf+width, sizeof(buf)-width,
+						"%*ld%s",
+						MaX(0,COL_VAL-width), S->TermsLeft, humanTermsLeftText);
 					MesPrint("%s", buf);
 				}
 				else
 #elif defined(WITHMPI)
 				if ( PF.me != MASTER && par == STATSPOSTSORT ) {
-					snprintf(buf, sizeof(buf),
-						"%16s         Terms in process= %10ld%s",
-						EXPRNAME(AR.CurExpr),S->TermsLeft,humanTermsLeftText);
+					int width = snprintf(buf, sizeof(buf),
+						"%*s%*s Terms in process=",
+						COL_EXP, EXPRNAME(AR.CurExpr), MaX(0,COL_SPA-overflow), "");
+					snprintf(buf+width, sizeof(buf)-width,
+						"%*ld%s",
+						MaX(0,COL_VAL-width), S->TermsLeft, humanTermsLeftText);
 					MesPrint("%s", buf);
 				}
 				else
 #endif
 				{
-					snprintf(buf, sizeof(buf),
-						"%16s         Terms %s = %10ld%s",
-						EXPRNAME(AR.CurExpr),FG.swmes[par],S->TermsLeft,
-						humanTermsLeftText);
+					int width = snprintf(buf, sizeof(buf),
+						"%*s%*s Terms %s",
+						COL_EXP, EXPRNAME(AR.CurExpr), MaX(0,COL_SPA-overflow), "",
+						FG.swmes[par]);
+					width += snprintf(buf+width, sizeof(buf)-width,
+						"%*s=",
+						MaX(0,COL_EQU-1-width), "");
+					snprintf(buf+width, sizeof(buf)-width,
+						"%*ld%s",
+						MaX(0,COL_VAL-width), S->TermsLeft, humanTermsLeftText);
 					MesPrint("%s", buf);
 				}
 			}
 
 			const WORD dig = DigitsIn(BASEPOSITION(*plspace));
-			snprintf(buf, sizeof(buf), "%24s Bytes used%*s=%11ld%s",
-				AC.Commercial,MiN(6,17-dig),"",BASEPOSITION(*plspace),
-				humanBytesText);
+			snprintf(buf, sizeof(buf),
+				"%*s Bytes used%*s=%11ld%s",
+				COL_EXP+COL_SPA, AC.Commercial, MiN(6,17-dig), "",
+				BASEPOSITION(*plspace), humanBytesText);
 			MesPrint("%s", buf);
 		}
 
 		if ( par == STATSPOSTSORT ) {
 			if ( AC.SortVerbose ) {
-				snprintf(buf, sizeof(buf), "%24s Unsorted bytes  =%11ld%s",
-					"",S->verbUnsortedSize,humanUnsortedBytesText);
+				snprintf(buf, sizeof(buf), "%*s Unsorted bytes  =%11ld%s",
+					COL_EXP+COL_SPA, "", S->verbUnsortedSize, humanUnsortedBytesText);
 				MesPrint("%s", buf);
-				snprintf(buf, sizeof(buf), "%24s Small Buffer    =%5ld,%5ld",
-					"",S->verbSBsortTerms,S->verbSBsortCap);
+				snprintf(buf, sizeof(buf), "%*s Small Buffer    =%5ld,%5ld",
+					COL_EXP+COL_SPA, "", S->verbSBsortTerms, S->verbSBsortCap);
 				MesPrint("%s", buf);
-				snprintf(buf, sizeof(buf), "%24s Large Buffer    =%5ld,%5ld",
-					"",S->verbLBsortPatches,S->verbLBsortCap);
+				snprintf(buf, sizeof(buf), "%*s Large Buffer    =%5ld,%5ld",
+					COL_EXP+COL_SPA, "", S->verbLBsortPatches, S->verbLBsortCap);
 				MesPrint("%s", buf);
-				snprintf(buf, sizeof(buf), "%24s Comparisons     =%11ld%s",
-					"",S->verbComparisons,humanComparisonsText);
+				snprintf(buf, sizeof(buf), "%*s Comparisons     =%11ld%s",
+					COL_EXP+COL_SPA, "", S->verbComparisons, humanComparisonsText);
 				MesPrint("%s", buf);
 			}
 		}


### PR DESCRIPTION
This resolves #833, improving the stats alignment when expression names are very long. Whitespace is taken from later columns, to at least align those, if possible.