### PR TITLE
Added "Largest Term" to stats for On SortVerbose

### DIFF
--- a/sources/float.c
+++ b/sources/float.c
@@ -1754,6 +1754,7 @@ Finished:
 		MUNLOCK(ErrorMessageLock);
 		Terminate(-1);
 	}
+	if ( **ps1 > S->verbMaxTermSize ) S->verbMaxTermSize = **ps1;
 	return(1);
 }
 

--- a/sources/normal.c
+++ b/sources/normal.c
@@ -260,6 +260,12 @@ int Normalize(PHEAD WORD *term)
 PrintTerm(term,"Normalize");
 */
 
+	if ( AT.SS == AT.S0 ) {
+		if ( *term > AT.SS->verbMaxTermSize ) {
+			AT.SS->verbMaxTermSize = *term;
+		}
+	}
+
 Restart:
 	didcontr = 0;
 	ReplaceType = -1;
@@ -4121,6 +4127,11 @@ NoRep:
 		MesPrint("Term too complex during normalization");
 		MUNLOCK(ErrorMessageLock);
 		goto NormMin;
+	}
+	if ( AT.SS == AT.S0 ) {
+		if ( ( m + i - termout ) > AT.SS->verbMaxTermSize ) {
+			AT.SS->verbMaxTermSize = m+i-termout;
+		}
 	}
 	if ( ReplaceType >= 0 ) {
 		t = n_coef;

--- a/sources/sort.c
+++ b/sources/sort.c
@@ -158,12 +158,14 @@ void WriteStats(POSITION *plspace, WORD par, WORD checkLogType)
 		char humanBytesText[HUMANSTRLEN] = "";
 		char humanUnsortedBytesText[HUMANSTRLEN] = "";
 		char humanComparisonsText[HUMANSTRLEN] = "";
+		char humanMaxTermSizeText[HUMANSTRLEN] = "";
 		if ( AC.HumanStatsFlag ) {
 			HumanString(humanGenTermsText, (float)(S->GenTerms), humanTermsSuffix);
 			HumanString(humanTermsLeftText, (float)(S->TermsLeft), humanTermsSuffix);
 			HumanString(humanBytesText, (float)(BASEPOSITION(*plspace)), humanBytesSuffix);
 			HumanString(humanUnsortedBytesText, (float)(S->verbUnsortedSize), humanBytesSuffix);
 			HumanString(humanComparisonsText, (float)(S->verbComparisons), humanTermsSuffix);
+			HumanString(humanMaxTermSizeText, (float)(S->verbMaxTermSize), humanTermsSuffix);
 		}
 
 		MLOCK(ErrorMessageLock);
@@ -325,6 +327,9 @@ void WriteStats(POSITION *plspace, WORD par, WORD checkLogType)
 				snprintf(buf, sizeof(buf), "%24s Comparisons     =%11ld%s",
 					"",S->verbComparisons,humanComparisonsText);
 				MesPrint("%s", buf);
+				snprintf(buf, sizeof(buf), "%24s Largest Term    =%11ld%s",
+					"",S->verbMaxTermSize,humanMaxTermSizeText);
+				MesPrint("%s", buf);
 			}
 		}
 
@@ -410,6 +415,7 @@ int NewSort(PHEAD0)
 
 	// Zero the SortVerbose counters:
 	S->verbComparisons = 0;
+	S->verbMaxTermSize = 0;
 	S->verbSBsortTerms = 0;
 	S->verbSBsortCap = 0;
 	S->verbLBsortPatches = 0;
@@ -1836,6 +1842,7 @@ RegEnd:
 		MUNLOCK(ErrorMessageLock);
 		Terminate(-1);
 	}
+	if ( **ps1 > S->verbMaxTermSize ) S->verbMaxTermSize = **ps1;
 	return(1);
 }
 
@@ -2022,6 +2029,7 @@ int AddPoly(PHEAD WORD **ps1, WORD **ps2)
 			MUNLOCK(ErrorMessageLock);
 			Terminate(-1);
 		}
+		if ( *m > S->verbMaxTermSize ) S->verbMaxTermSize = *m;
 	}
 	return(1);
 }
@@ -4253,6 +4261,7 @@ int StoreTerm(PHEAD WORD *term)
 
 	// Update SortVerbose counters
 	S->verbUnsortedSize += *term * sizeof(*term);
+	if ( S->verbMaxTermSize < *term ) S->verbMaxTermSize = *term;
 
 	if ( ( ( AP.PreDebug & DUMPTOSORT ) == DUMPTOSORT ) && AR.sLevel == 0 ) {
 #ifdef WITHPTHREADS

--- a/sources/structs.h
+++ b/sources/structs.h
@@ -1163,6 +1163,7 @@ typedef struct sOrT {
     LONG verbLBsortPatches;
     LONG verbLBsortCap;
     LONG verbUnsortedSize;
+    LONG verbMaxTermSize;
     int MaxPatches;             /* Maximum number of patches in large buffer */
     int MaxFpatches;            /* Maximum number of patches in one filesort */
     int type;                   /* Main, function or sub(routine) */

--- a/sources/threads.c
+++ b/sources/threads.c
@@ -2006,6 +2006,8 @@ void *RunSortBot(void *dummy)
 				SETBASEPOSITION(AN.theposition,0);
 				// Reset the sortbot comparison count
 				AT.SS->verbComparisons = 0;
+				// Reset the maximal term size count
+				AT.SS->verbMaxTermSize = 0;
 				break;
 /*
 			#] INISORTBOT : 
@@ -4114,10 +4116,13 @@ EndOfMerge:
 	// The total small/large buffer sort info is the sum of the thread info.
 	// The total comparison count is the sum of the thread counts.
 	// The total unsorted size is the sum of the total generated terms sizes
+	// The total maximal term size is the maximum of all maximal term sizes
 	S->GenTerms = 0;
 	for ( j = 1; j <= numberofworkers; j++ ) {
 		S->GenTerms += AB[j]->T.SS->GenTerms;
 		S->verbComparisons += AB[j]->T.SS->verbComparisons;
+		if ( S->verbMaxTermSize < AB[j]->T.SS->verbMaxTermSize )
+			S->verbMaxTermSize = AB[j]->T.SS->verbMaxTermSize;
 		S->verbSBsortTerms += AB[j]->T.SS->verbSBsortTerms;
 		S->verbSBsortCap += AB[j]->T.SS->verbSBsortCap;
 		S->verbLBsortPatches += AB[j]->T.SS->verbLBsortPatches;
@@ -4268,10 +4273,13 @@ int SortBotMasterMerge(void)
 	// The total small/large buffer sort info is the sum of the thread info.
 	// The total comparison count is the sum of the thread and sortbot counts.
 	// The total unsorted size is the sum of the total generated terms sizes
+	// The total maximal term size is the maximum of all maximal term sizes
 	S->GenTerms = 0;
 	for ( j = 1; j <= numberofworkers; j++ ) {
 		S->GenTerms += AB[j]->T.SS->GenTerms;
 		S->verbComparisons += AB[j]->T.SS->verbComparisons;
+		if ( S->verbMaxTermSize < AB[j]->T.SS->verbMaxTermSize )
+			S->verbMaxTermSize = AB[j]->T.SS->verbMaxTermSize;
 		S->verbSBsortTerms += AB[j]->T.SS->verbSBsortTerms;
 		S->verbSBsortCap += AB[j]->T.SS->verbSBsortCap;
 		S->verbLBsortPatches += AB[j]->T.SS->verbLBsortPatches;
@@ -4280,6 +4288,8 @@ int SortBotMasterMerge(void)
 	}
 	for ( j = numberofworkers+1; j <= numberofworkers+numberofsortbots; j++ ) {
 		S->verbComparisons += AB[j]->T.SS->verbComparisons;
+		if ( S->verbMaxTermSize < AB[j]->T.SS->verbMaxTermSize )
+			S->verbMaxTermSize = AB[j]->T.SS->verbMaxTermSize;
 	}
 
 	S->TermsLeft = numberofterms;


### PR DESCRIPTION
Added a new line to the statistics message in case of On SortVerbose that shows the maximal term size needed in the past module. For that the maximal term size was checked in:
- AddWithFloat
- AddCoef
- AddPoly
- StoreTerm
- Normalize (at 2 places: before normalization and after)
 
The value will be compared between threads and printed out. No large check have been done.