### PR TITLE
feat: warning if file setup parameters are ignored

### DIFF
--- a/check/features.frm
+++ b/check/features.frm
@@ -3289,3 +3289,33 @@ Local test = diagrams_(PHI3,{phi},{phi},{q1,q2},{q1,p2},1,0);
 .end
 assert runtime_error?('Invalid repeated momentum in diagrams_: q1')
 *--#] diagrams_err_8 :
+*--#[ warnings_1 :
+#-
+#define TEST "10"
+#: MaxTermSize 50K
+.sort
+Local test = `TEST';
+Print;
+.end
+assert stdout =~ exact_pattern(<<'EOF')
+Warning: ignoring out-of-place setup command:
+1.frm Line 4 ==> #: MaxTermSize 50K
+EOF
+assert result("test") =~ expr("10")
+*--#] warnings_1 :
+*--#[ warnings_2 :
+#-
+#: SmallSize 200M
+#: LargeSize 500M
+#define TEST "10"
+#: MaxTermSize 50K
+.sort
+Local test = `TEST';
+Print;
+.end
+assert stdout =~ exact_pattern(<<'EOF')
+Warning: ignoring out-of-place setup command:
+1.frm Line 6 ==> #: MaxTermSize 50K
+EOF
+assert result("test") =~ expr("10")
+*--#] warnings_2 :

--- a/sources/pre.c
+++ b/sources/pre.c
@@ -1216,7 +1216,16 @@ int PreProInstruction(void)
 			&& AP.PreIfStack[AP.PreIfLevel] == EXECUTINGIF ) 
 			AC.NoShowInput = 0;
 	}
-	else if ( *t == ':' ) {}
+	else if ( *t == ':' ) {
+		AP.FoundFileSetupCount--;
+		if ( AP.FoundFileSetupCount < 0 ) {
+			// This implies that TryFileSetups found fewer #: setup lines than
+			// are present in the file. This means that some were specified
+			// out-of-order, i.e. after a non-comment non-#: line. Warn.
+			MesPrint("Warning: ignoring out-of-place setup command:");
+			MesPrint("@%#%s", t);
+		}
+	}
 	else {
 retry:;
 		key = FindKeyWord(t,precommands,sizeof(precommands)/sizeof(KEYWORD));

--- a/sources/setfile.c
+++ b/sources/setfile.c
@@ -1174,6 +1174,7 @@ int TryFileSetups(void)
 	int oldNoShowInput = AC.NoShowInput;
 	UBYTE buff[SETBUFSIZE+1], *s, *t, *u, *settop, c;
 	LONG linenum, prevline;
+	AP.FoundFileSetupCount = 0;
 
 	if ( AC.CurrentStream == 0 ) return(error);
 	oldstream = AC.CurrentStream - AC.Streams;
@@ -1200,6 +1201,8 @@ int TryFileSetups(void)
 			while ( c != '\n' && c != ENDOFINPUT ) c = GetInput();
 			continue;
 		}
+		// Count the number of file setup parameters found
+		AP.FoundFileSetupCount++;
 		s = buff;
 		while ( ( c = GetInput() ) == ' ' || c == '\t' || c == '\r' ) {}
 		if ( c == ENDOFINPUT ) break;

--- a/sources/structs.h
+++ b/sources/structs.h
@@ -1655,6 +1655,7 @@ struct P_const {
     int     PreAssignLevel;        /* For nesting #$name = ...; assignments */
     int     MaxPreAssignLevel;     /* For nesting #$name = ...; assignments */
     int     fullnamesize;          /* size of the fullname buffer */
+    int     FoundFileSetupCount;   /* The number of "file setup" (#:) lines */
     WORD    DebugFlag;             /* (P) For debugging purposes */
     WORD    preError;              /* (P) Blocks certain types of execution */
     UBYTE   ComChar;               /* (P) Commentary character */


### PR DESCRIPTION
If file setup parameters (#: ...) are provided, but there are non-comment lines preceeding them, they are silently ignored. This is consistent with the manual, but easy to do by accident. Add a warning in this case.

---

This is not perfect, in that it won't catch things like
```
#: MaxTermSize 50K
#define TEST "10"
#: SmallSize 1G
```
but it will catch (probably) most instances of this.