### PR TITLE
Update the stale workflow configuration

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,7 +1,7 @@
 name: Close stale issues
 on:
   schedule:
-    - cron: '30 0 * * *'  # daily
+    - cron: '30 0 * * 1-5'  # Runs daily on weekdays
   workflow_dispatch:
 
 permissions:
@@ -26,4 +26,3 @@ jobs:
           days-before-pr-stale: -1  # Do not touch PRs.
           days-before-pr-close: -1
           remove-pr-stale-when-updated: false
-          operations-per-run: 15  # Keep stale operations low for now.


### PR DESCRIPTION
The stale workflow introduced in https://github.com/form-dev/form/pull/853 has completed its initial pass over the existing issues. We can now increase the `operations-per-run` limit from 15 to the default value of 30 (we could instead set it to a higher value, say, 100).

This PR also updates the cron schedule to avoid receiving stale notifications on weekends.
