### PR TITLE
build: recognise MinGW and ARM64 in the configure script

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -101,6 +101,9 @@ case $host_os in
 	cygwin* )
 		print_os="Cygwin"
 		;;
+	mingw* )
+		print_os="MinGW"
+		;;
 	freebsd* )
 		print_os="FreeBSD"
 		;;
@@ -123,6 +126,9 @@ case $host_cpu in
 		;;
 	x86_64 )
 		print_cpu="Opteron"
+		;;
+	aarch64 )
+		print_cpu="ARM64"
 		;;
 	alpha* )
 		print_cpu="Alpha"


### PR DESCRIPTION
In the `Deploy` workflow, the configure script currently prints the following on `ubuntu-24.04-arm`, `macos-arm`, and `windows-2022`, respectively:
```
  Compiling for: UNKNOWN CPU (aarch64) Linux (POSIX)

  Compiling for: UNKNOWN CPU (aarch64) OSX (POSIX)

  Compiling for: Opteron UNKNOWN OS (mingw32) (Windows)
```
This patch replaces these `UNKNOWN OS` and `UNKNOWN CPU` with `MinGW` and `ARM64`, respectively (though the exact choice of labels, including `MinGW`, `ARM64`, and `Opteron`, might be debatable).