### PR TITLE
build(configure): enable more sanitizers for --enable-sanitize

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1001,7 +1001,15 @@ if test "$my_test_DEBUGCOMPILEFLAGS" != set && test "x$enable_debug" = xyes; the
 		# Sanitizer option.
 		if test "x$enable_sanitize" = xyes; then
 			enable_sanitize=
-			for san in address undefined; do
+			for san in \
+				address \
+				pointer-compare \
+				pointer-subtract \
+				undefined \
+				bounds-strict \
+				float-divide-by-zero \
+				float-cast-overflow
+			do
 				if test "x$enable_sanitize" = x; then
 					tmp_sanitize=$san
 				else


### PR DESCRIPTION
With this PR, `--enable-sanitize` leads to `-fsanitize=address,pointer-compare,pointer-subtract,undefined,bounds-strict,float-divide-by-zero,float-cast-overflow` on supported compilers.

For example, `ASAN_OPTIONS=detect_invalid_pointer_pairs=2 /path/to/vorm test.frm` reports the following error for the example in https://github.com/form-dev/form/issues/866:
```
==563070==ERROR: AddressSanitizer: invalid-pointer-pair: 0x7aafb45f3a50 0x7bafb59e007c
    #0 0x567d4a700039 in CheckWild /home/tueda/work/form/sources/wildcard.c:1876
    #1 0x567d4a6aae05 in RunReplace /home/tueda/work/form/sources/transform.c:1624
    #2 0x567d4a6d8cc1 in RunTransform /home/tueda/work/form/sources/transform.c:782
...
```