### PR TITLE
build: make "make clean" clean

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -1,10 +1,9 @@
 SUBDIRS = doxygen manual devref
 dist_man1_MANS = form.1
 
-.PHONY: clean-local update_version_man
+.PHONY: update_version_man
 
-clean-local:
-	rm form.1
+CLEANFILES = form.1
 
 form.1: update_version_man
 	$(UPDATE_VERSION_MAN)

--- a/doc/devref/Makefile.am
+++ b/doc/devref/Makefile.am
@@ -12,7 +12,7 @@ TEXFILES = $(TEXSRC) $(MAIN).tex version.tex
 
 EXTRA_DIST = $(TEXSRC)
 
-.PHONY: dvi latex2html html ps pdf clean-local update_version_tex
+.PHONY: dvi latex2html html ps pdf update_version_tex
 
 # NOTE: htlatex invalidate .aux, .idx, .dvi files.
 HTMLCLEANFILES = idxmake.dvi idxmake.log $(MAIN).4ct $(MAIN).4dx $(MAIN).4ix \

--- a/doc/manual/Makefile.am
+++ b/doc/manual/Makefile.am
@@ -29,7 +29,7 @@ TEXFILES = $(TEXSRC) $(MAIN).tex version.tex
 
 EXTRA_DIST = $(TEXSRC)
 
-.PHONY: dvi latex2html html ps pdf clean-local update_version_tex
+.PHONY: dvi latex2html html ps pdf update_version_tex
 
 # NOTE: htlatex invalidate .aux, .idx, .dvi files.
 HTMLCLEANFILES = idxmake.dvi idxmake.log $(MAIN).4ct $(MAIN).4dx $(MAIN).4ix \


### PR DESCRIPTION
Running `make clean` twice results in the following error:
```
rm: cannot remove 'form.1': No such file or directory
```

A simple fix would be to add `-f` to `rm form.1`, but in this case we can use `CLEANFILES` because the target is a file rather than a directory.

The patch also removes redundant `clean-local` from the `.PHONY` target; Automake automatically adds `clean-local` to `.PHONY`.
