### PR TITLE
coverage: hide internal error paths from lcov

### DIFF
--- a/sources/argument.c
+++ b/sources/argument.c
@@ -605,10 +605,12 @@ ScaledVariety:;
 									break;
 								}
 								else {
+/* INTERNAL_ERROR_EXCL_START */
 									MLOCK(ErrorMessageLock);
-									MesPrint("Unknown fast notation found (TYPEARGTOEXTRASYMBOL)");
+									MesPrint("!>Unknown fast notation found (TYPEARGTOEXTRASYMBOL)");
 									MUNLOCK(ErrorMessageLock);
 									return(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 								}
 						}
 						n = FindSubexpression(tmp);
@@ -2004,8 +2006,10 @@ int ArgumentExplode(PHEAD WORD *term, WORD *thelist)
 						if ( i > 1 ) {
 TooMany:					old = AN.currentTerm;
 							AN.currentTerm = term;
+							MLOCK(ErrorMessageLock);
 							MesPrint("Too many arguments in output of ArgExplode");
 							MesPrint("Term = %t");
+							MUNLOCK(ErrorMessageLock);
 							AN.currentTerm = old;
 							return(-1);
 						}
@@ -2231,7 +2235,9 @@ int ArgFactorize(PHEAD WORD *argin, WORD *argout)
 			t += *t;
 		}
 		if ( sumcommu > 1 ) {
+			MLOCK(ErrorMessageLock);
 			MesPrint("ERROR: Cannot factorize an argument with more than one noncommuting object");
+			MUNLOCK(ErrorMessageLock);
 			Terminate(-1);
 		}
 	}
@@ -3294,11 +3300,15 @@ nextterm:						mm = mnext;
 	if ( argin2 != argin  ) TermFree(argin2,"TakeArgContent2");
 	return(argfree);
 Irreg:
-	MesPrint("Irregularity while sorting argument in TakeArgContent");
+/* INTERNAL_ERROR_EXCL_START */
+	MLOCK(ErrorMessageLock);
+	MesPrint("!>Irregularity while sorting argument in TakeArgContent");
+	MUNLOCK(ErrorMessageLock);
 	if ( argin3 != argin2 ) TermFree(argin3,"TakeArgContent3");
 	if ( argin2 != argin  ) TermFree(argin2,"TakeArgContent2");
 	Terminate(-1);
 	return(0);
+/* INTERNAL_ERROR_EXCL_STOP */
 }
 
 /*

--- a/sources/comexpr.c
+++ b/sources/comexpr.c
@@ -256,8 +256,10 @@ int DoExpr(UBYTE *inp, int type, int par)
 			AC.ProtoType[1] = osize;
 			AC.ProtoType[2] = i;
 			if ( PutOut(BHEAD OldWork+2,&pos,AR.outfile,0) < 0 ) {
-				MesPrint("&Cannot create expression");
+/* INTERNAL_ERROR_EXCL_START */
+				MesPrint("!>Cannot create expression");
 				error = -1;
+/* INTERNAL_ERROR_EXCL_STOP */
 			}
 			else {
 				Expressions[j].sizeprototype = OldWork[2];
@@ -270,8 +272,10 @@ int DoExpr(UBYTE *inp, int type, int par)
 				OldWork[SUBEXPSIZE+6] = 0;
 				if ( PutOut(BHEAD OldWork+2,&pos,AR.outfile,0) < 0
 				|| FlushOut(&pos,AR.outfile,0) ) {
-					MesPrint("&Cannot create expression");
+/* INTERNAL_ERROR_EXCL_START */
+					MesPrint("!>Cannot create expression");
 					error = -1;
+/* INTERNAL_ERROR_EXCL_STOP */
 				}
 				AR.outfile->POfull = AR.outfile->POfill;
 			}
@@ -1472,9 +1476,11 @@ int CoFillExpression(UBYTE *inp)
 		SeekFile(fi->handle,&oldposition,SEEK_CUR);
 		SetScratch(fi,&(Expressions[expnum].onfile));
 		if ( ISNEGPOS(Expressions[expnum].onfile) ) {
-			MesPrint("&File error in FillExpression");
+/* INTERNAL_ERROR_EXCL_START */
+			MesPrint("!>File error in FillExpression");
 			BACKINOUT
 			goto noway;
+/* INTERNAL_ERROR_EXCL_STOP */
 		}
 	}
 	else {

--- a/sources/compcomm.c
+++ b/sources/compcomm.c
@@ -953,8 +953,10 @@ int CoDelete(UBYTE *s)
 	int error = 0;
 	if ( StrICmp(s,(UBYTE *)"storage") == 0 ) {
 		if ( DeleteStore(1) < 0 ) {
-			MesPrint("&Cannot restart storage file");
+/* INTERNAL_ERROR_EXCL_START */
+			MesPrint("!>Cannot restart storage file");
 			error = 1;
+/* INTERNAL_ERROR_EXCL_STOP */
 		}
 	}
 	else {

--- a/sources/compiler.c
+++ b/sources/compiler.c
@@ -1123,9 +1123,11 @@ doexpr:					s += 2;
 #endif
 */
 							if ( ( renumber = GetTable(x2,&position,0) ) == 0 ) {
+/* INTERNAL_ERROR_EXCL_START */
 								error = 1;
-								MesPrint("&Problems getting information about stored expression %s(1)"
+								MesPrint("!>Problems getting information about stored expression %s(1)"
 								,EXPRNAME(x2));
+/* INTERNAL_ERROR_EXCL_STOP */
 							}
 							if ( renumber->symb.lo != AN.dummyrenumlist )
 								M_free(renumber->symb.lo,"VarSpace");
@@ -1372,9 +1374,11 @@ dofunction:			firstsumarg = 1;
 #endif
 */
 									if ( ( renumber = GetTable(x2,&position,0) ) == 0 ) {
+/* INTERNAL_ERROR_EXCL_START */
 										error = 1;
-										MesPrint("&Problems getting information about stored expression %s(2)"
+										MesPrint("!>Problems getting information about stored expression %s(2)"
 										,EXPRNAME(x2));
+/* INTERNAL_ERROR_EXCL_STOP */
 									}
 									if ( renumber->symb.lo != AN.dummyrenumlist )
 										M_free(renumber->symb.lo,"VarSpace");
@@ -1445,9 +1449,11 @@ dofunction:			firstsumarg = 1;
 									case TNUMBER1:
 										*t++ = -SNUMBER; *t++ = x2; break;
 									default:
-										MesPrint("&Internal error 435");
+/* INTERNAL_ERROR_EXCL_START */
+										MesPrint("!>Internal error 435");
 										error = 1;
 										*t++ = -SYMBOL; *t++ = x2; break;
+/* INTERNAL_ERROR_EXCL_STOP */
 								}
 								break;
 							case TSUBEXP:
@@ -1610,9 +1616,11 @@ dofunction:			firstsumarg = 1;
 									case TNUMBER1:
 										*t++ = SNUMBER; *t++ = 4; *t++ = x2; *t++ = 1; break;
 									default:
-										MesPrint("&Internal error 435");
+/* INTERNAL_ERROR_EXCL_START */
+										MesPrint("!>Internal error 435");
 										error = 1;
 										*t++ = SYMBOL; *t++ = 4; *t++ = x2; *t++ = 1; break;
+/* INTERNAL_ERROR_EXCL_STOP */
 								}
 								break;
 							default:
@@ -1658,9 +1666,11 @@ dofunction:			firstsumarg = 1;
 #endif
 */
 					if ( ( renumber = GetTable(x1,&position,0) ) == 0 ) {
+/* INTERNAL_ERROR_EXCL_START */
 						error = 1;
-						MesPrint("&Problems getting information about stored expression %s(3)"
+						MesPrint("!>Problems getting information about stored expression %s(3)"
 						,EXPRNAME(x1));
+/* INTERNAL_ERROR_EXCL_STOP */
 					}
 					if ( renumber->symb.lo != AN.dummyrenumlist )
 						M_free(renumber->symb.lo,"VarSpace");
@@ -1676,8 +1686,10 @@ dofunction:			firstsumarg = 1;
 */
 					s++;
 					if ( *s != TSUBEXP ) {
-						MesPrint("&Internal error 23");
+/* INTERNAL_ERROR_EXCL_START */
+						MesPrint("!>Internal error 23");
 						Terminate(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 					}
 					s++; x2 = 0; while ( *s >= 0 ) { x2 = 128*x2 + *s++; }
 					r = cbuf[subexpbuffers[x2].buffernum].rhs[subexpbuffers[x2].subexpnum];
@@ -1689,8 +1701,10 @@ dofunction:			firstsumarg = 1;
 						error = -1;
 					}
 					if ( *s != RBRACE ) {
-						MesPrint("&Internal error 23b");
+/* INTERNAL_ERROR_EXCL_START */
+						MesPrint("!>Internal error 23b");
 						Terminate(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 					}
 					s++;
 				}
@@ -2156,8 +2170,10 @@ dolast:
 					tt++;
 				}
 				if ( *tt != TNUMBER ) {
-					MesPrint("Internal problems(1) in CodeFactors");
+/* INTERNAL_ERROR_EXCL_START */
+					MesPrint("!>Internal problems(1) in CodeFactors");
 					return(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 				}
 				tt++; x2 = 0; while ( *tt >= 0 ) { x2 = 100*x2 + *tt++; }
 /*
@@ -2207,8 +2223,10 @@ dopower:
 					tt++;
 				}
 				if ( *tt != TNUMBER ) {
-					MesPrint("Internal problems(2) in CodeFactors");
+/* INTERNAL_ERROR_EXCL_START */
+					MesPrint("!>Internal problems(2) in CodeFactors");
 					return(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 				}
 				tt++; x2 = 0; while ( *tt >= 0 ) { x2 = 100*x2 + *tt++; }
 /*

--- a/sources/compress.c
+++ b/sources/compress.c
@@ -117,11 +117,13 @@ int SetupOutputGZIP(FILEHANDLE *f)
 	6: Initiate the deflation
 */
 	if ( deflateInit(f->zsp,AR.gzipCompress) != Z_OK ) {
+/* INTERNAL_ERROR_EXCL_START */
 		MLOCK(ErrorMessageLock);
-		MesPrint("Error from zlib: %s",f->zsp->msg);
+		MesPrint("!>Error from zlib: %s",f->zsp->msg);
 		MesCall("SetupOutputGZIP");
 		MUNLOCK(ErrorMessageLock);
 		Terminate(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 	}
 
 	return(0);
@@ -210,16 +212,20 @@ int PutOutputGZIP(FILEHANDLE *f)
 			return(0);
 		}
 		else {
+/* INTERNAL_ERROR_EXCL_START */
 			MLOCK(ErrorMessageLock);
-			MesPrint("%w avail_in = %d, avail_out = %d.",f->zsp->avail_in,f->zsp->avail_out);
+			MesPrint("!>%w avail_in = %d, avail_out = %d.",f->zsp->avail_in,f->zsp->avail_out);
 			MUNLOCK(ErrorMessageLock);
 			break;
+/* INTERNAL_ERROR_EXCL_STOP */
 		}
 	}
+/* INTERNAL_ERROR_EXCL_START */
 	MLOCK(ErrorMessageLock);
-	MesPrint("%wError in gzip handling of output. zerror = %d",zerror);
+	MesPrint("!>%wError in gzip handling of output. zerror = %d",zerror);
 	MUNLOCK(ErrorMessageLock);
 	return(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 }
 
 /*
@@ -350,21 +356,23 @@ int FlushOutputGZIP(FILEHANDLE *f)
 		f->zsp->avail_out = f->ziosize;
 		f->zsp->total_out = 0;
         if ( ( zerror = deflateEnd(f->zsp) ) == Z_OK ) return(0);
+/* INTERNAL_ERROR_EXCL_START */
 		MLOCK(ErrorMessageLock);
 		if ( f->zsp->msg ) {
-			MesPrint("%wError in finishing gzip handling of output: %s",f->zsp->msg);
+			MesPrint("!>%wError in finishing gzip handling of output: %s",f->zsp->msg);
 		}
 		else {
-			MesPrint("%wError in finishing gzip handling of output.");
+			MesPrint("!>%wError in finishing gzip handling of output.");
 		}
 		MUNLOCK(ErrorMessageLock);
 	}
 	else {
 		MLOCK(ErrorMessageLock);
-		MesPrint("%wError in gzip handling of output.");
+		MesPrint("!>%wError in gzip handling of output.");
 		MUNLOCK(ErrorMessageLock);
 	}
 	return(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 }
 
 /*
@@ -451,12 +459,14 @@ int SetupAllInputGZIP(SORTING *S)
 			4: Initiate the inflation
 */
 			if ( inflateInit(zsp) != Z_OK ) {
+/* INTERNAL_ERROR_EXCL_START */
 				MLOCK(ErrorMessageLock);
-				if ( zsp->msg ) MesPrint("%wError from inflateInit: %s",zsp->msg);
-				else            MesPrint("%wError from inflateInit");
+				if ( zsp->msg ) MesPrint("!>%wError from inflateInit: %s",zsp->msg);
+				else            MesPrint("!>%wError from inflateInit");
 				MesCall("SetupAllInputGZIP");
 				MUNLOCK(ErrorMessageLock);
 				Terminate(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 			}
 			NumberOpened++;
 		}
@@ -527,10 +537,12 @@ LONG FillInputGZIP(FILEHANDLE *f, POSITION *position, UBYTE *buffer, LONG buffer
 					return(zsp->total_out);
 				}
 				if ( readsize < 0 ) {
+/* INTERNAL_ERROR_EXCL_START */
 					MLOCK(ErrorMessageLock);
-					MesPrint("%wFillInputGZIP: Read error during compressed sort.");
+					MesPrint("!>%wFillInputGZIP: Read error during compressed sort.");
 					MUNLOCK(ErrorMessageLock);
 					return(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 				}
 				ADDPOS(f->filesize,readsize);
 				ADDPOS(f->POposition,readsize);
@@ -630,10 +642,12 @@ LONG FillInputGZIP(FILEHANDLE *f, POSITION *position, UBYTE *buffer, LONG buffer
 					return(zsp->total_out);
 				}
 				if ( readsize < 0 ) {
+/* INTERNAL_ERROR_EXCL_START */
 					MLOCK(ErrorMessageLock);
-					MesPrint("%wFillInputGZIP: Read error during compressed sort.");
+					MesPrint("!>%wFillInputGZIP: Read error during compressed sort.");
 					MUNLOCK(ErrorMessageLock);
 					return(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 				}
 				ADDPOS(f->filesize,readsize);
 				ADDPOS(f->POposition,readsize);
@@ -690,10 +704,12 @@ LONG FillInputGZIP(FILEHANDLE *f, POSITION *position, UBYTE *buffer, LONG buffer
 			if ( zerror == Z_OK || zerror == Z_STREAM_END ) return(readsize);
 		}
 
+/* INTERNAL_ERROR_EXCL_START */
 		MLOCK(ErrorMessageLock);
-		MesPrint("%wFillInputGZIP: Error in gzip handling of input. zerror = %d",zerror);
+		MesPrint("!>%wFillInputGZIP: Error in gzip handling of input. zerror = %d",zerror);
 		MUNLOCK(ErrorMessageLock);
 		return(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 	}
 	else {
 #ifdef GZIPDEBUG
@@ -711,10 +727,12 @@ LONG FillInputGZIP(FILEHANDLE *f, POSITION *position, UBYTE *buffer, LONG buffer
 		UNLOCK(f->pthreadslock);
 #endif
 		if ( readsize < 0 ) {
+/* INTERNAL_ERROR_EXCL_START */
 			MLOCK(ErrorMessageLock);
-			MesPrint("%wFillInputGZIP: Read error during uncompressed sort.");
+			MesPrint("!>%wFillInputGZIP: Read error during uncompressed sort.");
 			MesPrint("%w++Reading %l bytes at position %10p",buffersize,position);
 			MUNLOCK(ErrorMessageLock);
+/* INTERNAL_ERROR_EXCL_STOP */
 		}
 		return(readsize);
 	}

--- a/sources/comtool.c
+++ b/sources/comtool.c
@@ -148,11 +148,7 @@ WORD *DoubleCbuffer(int num, WORD *w,int par)
 	WORD *w1, *w2;
 	LONG offset, j, i;
 	DUMMYUSE(par)
-/*
-	MLOCK(ErrorMessageLock);
-		MesPrint(" doubleCbuffer: par = %d",par);
-	MUNLOCK(ErrorMessageLock);
-*/
+
 	w1 = C->Buffer; w2 = newbuffer;
 	i = w - w1;
 	j = i & 7;
@@ -441,8 +437,10 @@ int InsTree(int bufnum, int h)
 			return(p->value);
 		}
 	}
-	MesPrint("We vallen uit de boom!");
+/* INTERNAL_ERROR_EXCL_START */
+	MesPrint("!>We vallen uit de boom!");
 	Terminate(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 	return(h);
 balance:;
 	for (;;) {

--- a/sources/dollar.c
+++ b/sources/dollar.c
@@ -900,10 +900,12 @@ void WildDollars(PHEAD WORD *term)
 		t = m - 4;
 		while ( *t == LOADDOLLAR || *t == FROMSET || *t == SETTONUM ) t -= 4;
 		if ( t < wildvalue ) {
+/* INTERNAL_ERROR_EXCL_START */
 			MLOCK(ErrorMessageLock);
-			MesPrint("&Serious bug in wildcard prototype. Found in WildDollars");
+			MesPrint("!>Serious bug in wildcard prototype. Found in WildDollars");
 			MUNLOCK(ErrorMessageLock);
 			Terminate(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 		}
 		numdollar = m[2];
 		d = Dollars + numdollar;
@@ -2511,10 +2513,12 @@ int TwoExprCompare(WORD *buf1, WORD *buf2, int oprtr)
 			case LESSEQUAL: return(1);
 		}
 	}
+/* INTERNAL_ERROR_EXCL_START */
 	MLOCK(ErrorMessageLock);
-	MesPrint("@Internal problems with operator in $( )");
+	MesPrint("!>Internal problems with operator in $( )");
 	MUNLOCK(ErrorMessageLock);
 	Terminate(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 	return(0);
 }
 

--- a/sources/execute.c
+++ b/sources/execute.c
@@ -1114,8 +1114,10 @@ if ( AC.SwitchInArray > 0 ) {
 		AC.HideLevel = 0;
 		if ( par == CLEARMODULE ) {
 			if ( DeleteStore(0) < 0 ) {
-				MesPrint("Cannot restart the storage file");
+/* INTERNAL_ERROR_EXCL_START */
+				MesPrint("!>Cannot restart the storage file");
 				RetCode = -1;
+/* INTERNAL_ERROR_EXCL_STOP */
 			}
 			else RetCode = 0;
 			CleanUp(1);
@@ -1808,8 +1810,10 @@ void ExchangeExpressions(int num1, int num2)
 		SeekFile(AR.StoreData.Handle,&(e1->onfile),SEEK_SET);
 		if ( WriteFile(AR.StoreData.Handle,(UBYTE *)ind,
 		(LONG)(sizeof(INDEXENTRY))) != sizeof(INDEXENTRY) ) {
-			MesPrint("File error while exchanging expressions");
+/* INTERNAL_ERROR_EXCL_START */
+			MesPrint("!>File error while exchanging expressions");
 			Terminate(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 		}
 		FlushFile(AR.StoreData.Handle);
 	}
@@ -1832,8 +1836,10 @@ void ExchangeExpressions(int num1, int num2)
 		SeekFile(AR.StoreData.Handle,&(e2->onfile),SEEK_SET);
 		if ( WriteFile(AR.StoreData.Handle,(UBYTE *)ind,
 		(LONG)(sizeof(INDEXENTRY))) != sizeof(INDEXENTRY) ) {
-			MesPrint("File error while exchanging expressions");
+/* INTERNAL_ERROR_EXCL_START */
+			MesPrint("!>File error while exchanging expressions");
 			Terminate(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 		}
 		FlushFile(AR.StoreData.Handle);
 	}

--- a/sources/factor.c
+++ b/sources/factor.c
@@ -55,10 +55,12 @@ int FactorIn(PHEAD WORD *term, WORD level)
 	while ( ( t < tstop ) && ( *t != FACTORIN || ( ( *t == FACTORIN )
 	 && ( t[FUNHEAD] != -DOLLAREXPRESSION || t[1] != FUNHEAD+2 ) ) ) ) t += t[1];
 	if ( t >= tstop ) {
+/* INTERNAL_ERROR_EXCL_START */
 		MLOCK(ErrorMessageLock);
-		MesPrint("Internal error. Could not find proper factorin_ function.");
+		MesPrint("!>Internal error. Could not find proper factorin_ function.");
 		MUNLOCK(ErrorMessageLock);
 		return(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 	}
 	oldwork = AT.WorkPointer;
 	d = Dollars + t[FUNHEAD+1];
@@ -443,12 +445,14 @@ int FactorInExpr(PHEAD WORD *term, WORD level)
 		t += t[1];
 	}
 	if ( t >= tstop ) {
+/* INTERNAL_ERROR_EXCL_START */
 		MLOCK(ErrorMessageLock);
-		MesPrint("Internal error. Could not find proper factorin_ function.");
+		MesPrint("!>Internal error. Could not find proper factorin_ function.");
 		MUNLOCK(ErrorMessageLock);
 		NumberFree(GCDbuffer,"FactorInExpr"); NumberFree(GCDbuffer2,"FactorInExpr");
 		NumberFree(LCMbuffer,"FactorInExpr"); NumberFree(LCMb,"FactorInExpr"); NumberFree(LCMc,"FactorInExpr");
 		return(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 	}
 	oldwork = AT.WorkPointer;
 	if ( AT.previousEfactor && ( expr == AT.previousEfactor[0] ) ) {
@@ -544,12 +548,14 @@ int FactorInExpr(PHEAD WORD *term, WORD level)
 	SeekScratch(file,&oldposition);
 	SetScratch(file,&position);
 	if ( GetTerm(BHEAD oldwork) <= 0 ) {
+/* INTERNAL_ERROR_EXCL_START */
 		MLOCK(ErrorMessageLock);
-		MesPrint("(5) Expression %d has problems in scratchfile",expr);
+		MesPrint("!>(5) Expression %d has problems in scratchfile",expr);
 		MUNLOCK(ErrorMessageLock);
 		NumberFree(GCDbuffer,"FactorInExpr"); NumberFree(GCDbuffer2,"FactorInExpr");
 		NumberFree(LCMbuffer,"FactorInExpr"); NumberFree(LCMb,"FactorInExpr"); NumberFree(LCMc,"FactorInExpr");
 		return(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 	}
 	SeekScratch(file,&startposition);
 	SeekScratch(file,&position);

--- a/sources/findpat.c
+++ b/sources/findpat.c
@@ -1399,10 +1399,12 @@ OneWild:
 			#] DELTAS : 
 */
 		else {
+/* INTERNAL_ERROR_EXCL_START */
 			MLOCK(ErrorMessageLock);
-			MesPrint("Pattern not yet implemented");
+			MesPrint("!>Pattern not yet implemented");
 			MUNLOCK(ErrorMessageLock);
 			Terminate(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 		}
 	} while ( m < mstop );
 	return(1);

--- a/sources/flintinterface.cc
+++ b/sources/flintinterface.cc
@@ -1761,10 +1761,12 @@ void flint::ratfun_read_mpoly(const WORD *a, fmpz_mpoly_t num, fmpz_mpoly_t den,
 	}
 	else {
 		// The denominator is 1
+/* INTERNAL_ERROR_EXCL_START */
 		MLOCK(ErrorMessageLock);
-		MesPrint("implement this");
+		MesPrint("!>implement this");
 		MUNLOCK(ErrorMessageLock);
 		Terminate(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 	}
 	if ( a < arg_stop ) {
 		MLOCK(ErrorMessageLock);
@@ -1818,10 +1820,12 @@ void flint::ratfun_read_poly(const WORD *a, fmpz_poly_t num, fmpz_poly_t den) {
 	}
 	else {
 		// The denominator is 1
+/* INTERNAL_ERROR_EXCL_START */
 		MLOCK(ErrorMessageLock);
-		MesPrint("implement this");
+		MesPrint("!>implement this");
 		MUNLOCK(ErrorMessageLock);
 		Terminate(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 	}
 	if ( a < arg_stop ) {
 		MLOCK(ErrorMessageLock);

--- a/sources/flintwrap.cc
+++ b/sources/flintwrap.cc
@@ -182,10 +182,12 @@ WORD* flint_mul(PHEAD WORD *a, WORD *b) {
 WORD* flint_ratfun_add(PHEAD WORD *t1, WORD *t2) {
 
 	if ( AR.PolyFunExp == 1 ) {
+/* INTERNAL_ERROR_EXCL_START */
 		MLOCK(ErrorMessageLock);
-		MesPrint("flint_ratfun_add: PolyFunExp unimplemented.");
+		MesPrint("!>flint_ratfun_add: PolyFunExp unimplemented.");
 		MUNLOCK(ErrorMessageLock);
 		Terminate(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 	}
 
 	WORD *oldworkpointer = AT.WorkPointer;

--- a/sources/index.c
+++ b/sources/index.c
@@ -385,9 +385,10 @@ void PutBracketInIndex(PHEAD WORD *term, POSITION *newpos)
 /*
 problems:;
 */
+/* INTERNAL_ERROR_EXCL_START */
 				*term = oldsize; oldt[0] = a[0]; oldt[1] = a[1]; oldt[2] = a[2];
 				MLOCK(ErrorMessageLock);
-				MesPrint("Error!!!! Illegal bracket sequence detected in PutBracketInIndex");
+				MesPrint("!>Error! Illegal bracket sequence detected in PutBracketInIndex");
 #ifdef WITHPTHREADS
 				MesPrint("Worker = %w");
 #endif
@@ -396,6 +397,7 @@ problems:;
 				MUNLOCK(ErrorMessageLock);
 				AT.fromindex = 0;
 				Terminate(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 			}
 			i = -1;
 		}

--- a/sources/lus.c
+++ b/sources/lus.c
@@ -914,9 +914,11 @@ LONG StartLoops(PHEAD WORD *term,WORD level,LONG vert,WORD nvert,
 /*
 		If we come here, we have a problem.
 */
-		MesPrint("Internal error in StartLoops. Object not found.");
+/* INTERNAL_ERROR_EXCL_START */
+		MesPrint("!>Internal error in StartLoops. Object not found.");
 		Terminate(-1);
 		return(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 havestart:
 		AT.pWorkSpace[vert+nvert] = vstart;
 /*

--- a/sources/minos.c
+++ b/sources/minos.c
@@ -296,9 +296,11 @@ int ReadIndex(DBASE *d)
 */
 	if ( d->info.numberofindexblocks <= 0 ) return(0);
 	if ( sizeof(INDEXBLOCK)*d->info.numberofindexblocks > MAXINDEXSIZE ) {
-		MesPrint("We need more than %ld bytes for the index.\n",MAXINDEXSIZE);
+/* INTERNAL_ERROR_EXCL_START */
+		MesPrint("!>We need more than %ld bytes for the index.\n",MAXINDEXSIZE);
 		MesPrint("The file %s may not be a proper database\n",d->name);
 		return(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 	}
 	size = sizeof(INDEXBLOCK *)*d->info.numberofindexblocks;
 	if ( ( ib = (INDEXBLOCK **)Malloc1(size,"tb,index") ) == 0 ) return(-1);
@@ -328,19 +330,23 @@ int ReadIndex(DBASE *d)
 	for ( i = d->info.numberofindexblocks - 1; i >= 0; i-- ) {
 		fseek(d->handle,position,SEEK_SET);
 		if ( minosread(d->handle,(char *)(&scratchblock),sizeof(INDEXBLOCK)) ) {
-			MesPrint("Error while reading file %s\n",d->name);
+/* INTERNAL_ERROR_EXCL_START */
+			MesPrint("!>Error while reading file %s\n",d->name);
 thisiswrong:
 			for ( i = 0; i < d->info.numberofnamesblocks; i++ ) M_free(ina[i],"index names block");
 			M_free(ina,"tb,indexnames");
 			for ( i = 0; i < d->info.numberofindexblocks; i++ ) M_free(ib[i],"tb,indexblock");
 			M_free(ib,"tb,index");
 			return(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 		}
 		convertblock(&scratchblock,ib[i],FROMDISK);
 		if ( ib[i]->position != position ||
 		( ib[i]->previousblock <= 0 && i > 0 ) ) {
-			MesPrint("File %s has inconsistent contents\n",d->name);
+/* INTERNAL_ERROR_EXCL_START */
+			MesPrint("!>File %s has inconsistent contents\n",d->name);
 			goto thisiswrong;
+/* INTERNAL_ERROR_EXCL_STOP */
 		}
 		position = ib[i]->previousblock;
 	}
@@ -356,14 +362,18 @@ thisiswrong:
 	for ( i = d->info.numberofnamesblocks - 1; i >= 0; i-- ) {
 		fseek(d->handle,position,SEEK_SET);
 		if ( minosread(d->handle,(char *)(&scratchnamesblock),sizeof(NAMESBLOCK)) ) {
-			MesPrint("Error while reading file %s\n",d->name);
+/* INTERNAL_ERROR_EXCL_START */
+			MesPrint("!>Error while reading file %s\n",d->name);
 			goto thisiswrong;
+/* INTERNAL_ERROR_EXCL_STOP */
 		}
 		convertnamesblock(&scratchnamesblock,ina[i],FROMDISK);
 		if ( ina[i]->position != position ||
 		( ina[i]->previousblock <= 0 && i > 0 ) ) {
-			MesPrint("File %s has inconsistent contents\n",d->name);
+/* INTERNAL_ERROR_EXCL_START */
+			MesPrint("!>File %s has inconsistent contents\n",d->name);
 			goto thisiswrong;
+/* INTERNAL_ERROR_EXCL_STOP */
 		}
 		position = ina[i]->previousblock;
 	}
@@ -399,15 +409,19 @@ thisiswrong:
 int WriteIndexBlock(DBASE *d,MLONG num)
 {
 	if ( num >= d->info.numberofindexblocks ) {
-		MesPrint("Illegal number specified for number of index blocks\n");
+/* INTERNAL_ERROR_EXCL_START */
+		MesPrint("!>Illegal number specified for number of index blocks\n");
 		return(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 	}
 	fseek(d->handle,d->iblocks[num]->position,SEEK_SET);
 	convertblock(d->iblocks[num],&scratchblock,TODISK);
 	if ( minoswrite(d->handle,(char *)(&scratchblock),sizeof(INDEXBLOCK)) ) {
-		MesPrint("Error while writing an index block in file %s\n",d->name);
+/* INTERNAL_ERROR_EXCL_START */
+		MesPrint("!>Error while writing an index block in file %s\n",d->name);
 		MesPrint("File may be unreliable now\n");
 		return(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 	}
 	return(0);
 }
@@ -420,15 +434,19 @@ int WriteIndexBlock(DBASE *d,MLONG num)
 int WriteNamesBlock(DBASE *d,MLONG num)
 {
 	if ( num >= d->info.numberofnamesblocks ) {
-		MesPrint("Illegal number specified for number of names blocks\n");
+/* INTERNAL_ERROR_EXCL_START */
+		MesPrint("!>Illegal number specified for number of names blocks\n");
 		return(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 	}
 	fseek(d->handle,d->nblocks[num]->position,SEEK_SET);
 	convertnamesblock(d->nblocks[num],&scratchnamesblock,TODISK);
 	if ( minoswrite(d->handle,(char *)(&scratchnamesblock),sizeof(NAMESBLOCK)) ) {
-		MesPrint("Error while writing a names block in file %s\n",d->name);
+/* INTERNAL_ERROR_EXCL_START */
+		MesPrint("!>Error while writing a names block in file %s\n",d->name);
 		MesPrint("File may be unreliable now\n");
 		return(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 	}
 	return(0);
 }
@@ -447,14 +465,18 @@ int WriteIndex(DBASE *d)
 	if ( d->nblocks == 0 ) return(0);
 	for ( i = 0; i < d->info.numberofindexblocks; i++ ) {
 		if ( d->iblocks[i] == 0 ) {
-			MesPrint("Error: unassigned index blocks. Cannot write\n");
+/* INTERNAL_ERROR_EXCL_START */
+			MesPrint("!>Error: unassigned index blocks. Cannot write\n");
 			return(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 		}
 	}
 	for ( i = 0; i < d->info.numberofnamesblocks; i++ ) {
 		if ( d->nblocks[i] == 0 ) {
-			MesPrint("Error: unassigned names blocks. Cannot write\n");
+/* INTERNAL_ERROR_EXCL_START */
+			MesPrint("!>Error: unassigned names blocks. Cannot write\n");
 			return(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 		}
 	}
 	d->info.lastindexblock = -1;
@@ -470,9 +492,11 @@ int WriteIndex(DBASE *d)
 		else fseek(d->handle,position,SEEK_SET);
 		convertblock(d->iblocks[i],&scratchblock,TODISK);
 		if ( minoswrite(d->handle,(char *)(&scratchblock),sizeof(INDEXBLOCK)) ) {
-			MesPrint("Error while writing index of file %s",d->name);
+/* INTERNAL_ERROR_EXCL_START */
+			MesPrint("!>Error while writing index of file %s",d->name);
 			d->iblocks[i]->position = -1;
 			return(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 		}
 		d->info.lastindexblock = position;
 	}
@@ -489,9 +513,11 @@ int WriteIndex(DBASE *d)
 		else fseek(d->handle,position,SEEK_SET);
 		convertnamesblock(d->nblocks[i],&scratchnamesblock,TODISK);
 		if ( minoswrite(d->handle,(char *)(&scratchnamesblock),sizeof(NAMESBLOCK)) ) {
-			MesPrint("Error while writing index of file %s",d->name);
+/* INTERNAL_ERROR_EXCL_START */
+			MesPrint("!>Error while writing index of file %s",d->name);
 			d->nblocks[i]->position = -1;
 			return(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 		}
 		d->info.lastnameblock = position;
 	}
@@ -509,8 +535,10 @@ int WriteIniInfo(DBASE *d)
 	fseek(d->handle,0,SEEK_SET);
 	convertiniinfo(&(d->info),&inf,TODISK);
 	if ( minoswrite(d->handle,(char *)(&inf),sizeof(INIINFO)) ) {
-		MesPrint("Error while writing masterindex of file %s",d->name);
+/* INTERNAL_ERROR_EXCL_START */
+		MesPrint("!>Error while writing masterindex of file %s",d->name);
 		return(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 	}
 	return(0);
 }
@@ -525,15 +553,19 @@ int ReadIniInfo(DBASE *d)
 	INIINFO inf;
 	fseek(d->handle,0,SEEK_SET);
 	if ( minosread(d->handle,(char *)(&inf),sizeof(INIINFO)) ) {
-		MesPrint("Error while reading masterindex of file %s",d->name);
+/* INTERNAL_ERROR_EXCL_START */
+		MesPrint("!>Error while reading masterindex of file %s",d->name);
 		return(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 	}
 	convertiniinfo(&inf,&(d->info),FROMDISK);
 	if ( d->info.entriesinindex < 0
 	|| d->info.numberofindexblocks < 0
 	|| d->info.lastindexblock < 0 ) {
-		MesPrint("The file %s is not a proper database\n",d->name);
+/* INTERNAL_ERROR_EXCL_START */
+		MesPrint("!>The file %s is not a proper database\n",d->name);
 		return(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 	}
 	return(0);
 }
@@ -660,6 +692,7 @@ DBASE *NewDbase(char *name,MLONG number)
 
 	if ( WriteIniInfo(d) ) {
 getout:
+/* INTERNAL_ERROR_EXCL_START */
 		fclose(f);
 		remove(d->fullname);
 		if ( d->name ) { M_free(d->name,"name tablebase"); d->name = 0; }
@@ -668,12 +701,15 @@ getout:
 		M_free(d->iblocks,"new database");
 		NumTableBases--;
 		return(0);
+/* INTERNAL_ERROR_EXCL_STOP */
 	}
 	for ( i = 0; i < numblocks; i++ ) {
 		if ( ( d->iblocks[i] = (INDEXBLOCK *)Malloc1(sizeof(INDEXBLOCK),
 		"index blocks of new database") ) == 0 ) {
+/* INTERNAL_ERROR_EXCL_START */
 			while ( --i >= 0 ) M_free(d->iblocks[i],"index blocks of new database");
 			goto getout;
+/* INTERNAL_ERROR_EXCL_STOP */
 		}
 		if ( i > 0 ) d->iblocks[i]->previousblock = d->iblocks[i-1]->position;
 		else d->iblocks[i]->previousblock = -1;
@@ -697,8 +733,10 @@ getout:
 			}
 		convertblock(d->iblocks[i],&scratchblock,TODISK);
 		if ( minoswrite(d->handle,(char *)(&scratchblock),sizeof(INDEXBLOCK)) ) {
-			MesPrint("Error while writing new index blocks\n");
+/* INTERNAL_ERROR_EXCL_START */
+			MesPrint("!>Error while writing new index blocks\n");
 			goto getout;
+/* INTERNAL_ERROR_EXCL_STOP */
 		}
 	}
 	for ( i = 0; i < numnameblocks; i++ ) {
@@ -715,10 +753,12 @@ getout:
 		for ( j = 0; j < NAMETABLESIZE; j++ ) *s++ = 0;
 		convertnamesblock(d->nblocks[i],&scratchnamesblock,TODISK);
 		if ( minoswrite(d->handle,(char *)(&scratchnamesblock),sizeof(NAMESBLOCK)) ) {
-			MesPrint("Error while writing new names blocks\n");
+/* INTERNAL_ERROR_EXCL_START */
+			MesPrint("!>Error while writing new names blocks\n");
 			for ( i = 0; i < numnameblocks; i++ ) M_free(d->nblocks[i],"names blocks of new database");
 			for ( i = 0; i < numblocks; i++ ) M_free(d->iblocks[i],"index blocks of new database");
 			goto getout;
+/* INTERNAL_ERROR_EXCL_STOP */
 		}
 	}
 	d->info.firstindexblock = d->iblocks[0]->position;
@@ -1049,9 +1089,11 @@ int PutTableNames(DBASE *d)
 		else fseek(d->handle,d->nblocks[i]->position,SEEK_SET);
 		convertnamesblock(d->nblocks[i],&scratchnamesblock,TODISK);
 		if ( minoswrite(d->handle,(char *)(&scratchnamesblock),sizeof(NAMESBLOCK)) ) {
-			MesPrint("Error while writing names blocks\n");
+/* INTERNAL_ERROR_EXCL_START */
+			MesPrint("!>Error while writing names blocks\n");
 			FreeTableBase(d);
 			return(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 		}
 	}
 	d->info.lastnameblock = d->nblocks[d->info.numberofnamesblocks-1]->position;
@@ -1073,16 +1115,20 @@ int AddToIndex(DBASE *d,MLONG number)
 	if ( number == 0 ) return(0);
 	else if ( number < 0 ) {
 		if ( d->info.entriesinindex < -number ) {
-			MesPrint("There are only %ld entries in the index of file %s\n",
+/* INTERNAL_ERROR_EXCL_START */
+			MesPrint("!>There are only %ld entries in the index of file %s\n",
 			d->info.entriesinindex,d->name);
 			return(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 		}
 		d->info.entriesinindex += number;
 dowrite:
 		if ( WriteIniInfo(d) ) {
+/* INTERNAL_ERROR_EXCL_START */
 			d->info.entriesinindex -= number;
-			MesPrint("File may be corrupted\n");
+			MesPrint("!>File may be corrupted\n");
 			return(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 		}
 	}
 	else if ( d->info.entriesinindex+number <=
@@ -1125,20 +1171,24 @@ dowrite:
 			ib[i]->position = ftell(d->handle);
 			convertblock(ib[i],&scratchblock,TODISK);
 			if ( minoswrite(d->handle,(char *)(&scratchblock),sizeof(INDEXBLOCK)) ) {
-				MesPrint("Error while writing new index of file %s",d->name);
+/* INTERNAL_ERROR_EXCL_START */
+				MesPrint("!>Error while writing new index of file %s",d->name);
 				FreeTableBase(d);
 				return(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 			}
 		}
 		d->info.lastindexblock = ib[newnumofindexblocks-1]->position;
 		d->info.firstindexblock = ib[0]->position;
 		d->info.numberofindexblocks = newnumofindexblocks;
 		if ( WriteIniInfo(d) ) {
+/* INTERNAL_ERROR_EXCL_START */
 			d->info.numberofindexblocks = oldnumofindexblocks;
 			d->info.entriesinindex -= number;
-			MesPrint("File may be corrupted\n");
+			MesPrint("!>File may be corrupted\n");
 			FreeTableBase(d);
 			return(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 		}
 		M_free(d->iblocks,"AddToIndex");
 		d->iblocks = ib;
@@ -1254,10 +1304,12 @@ int WriteObject(DBASE *d,MLONG tablenumber,char *arguments,char *rhs,MLONG numbe
 		ZWRAP_useZSTDcompression(0);
 #endif
 		if ( ( error = compress((Bytef *)buffer,&newsize,(Bytef *)rhs,ssize) ) != Z_OK ) {
+/* INTERNAL_ERROR_EXCL_START */
+			MesPrint("!>Due to error no compress used for element %s in file %s\n",arguments,d->name);
 			MesPrint("Error = %d\n",error);
-			MesPrint("Due to error no compress used for element %s in file %s\n",arguments,d->name);
 			M_free(buffer,"tb,WriteObject");
 			buffer = 0;
+/* INTERNAL_ERROR_EXCL_STOP */
 		}
 #ifdef WITHZSTD
 		ZWRAP_useZSTDcompression(old_isUsingZSTDcompression);
@@ -1270,8 +1322,10 @@ int WriteObject(DBASE *d,MLONG tablenumber,char *arguments,char *rhs,MLONG numbe
 	}
 #endif
 	if ( minoswrite(d->handle,rhs,size) ) {
-		MesPrint("Error while writing rhs\n");
+/* INTERNAL_ERROR_EXCL_START */
+		MesPrint("!>Error while writing rhs\n");
 		return(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 	}
 	obj->position = position;
 	obj->size = size;
@@ -1345,20 +1399,24 @@ foundelement:;
 	else buffer2 = 0;
 #endif
 	if ( minosread(d->handle,buffer1,obj->size) ) {
-		MesPrint("Could not read rhs %s in file %s\n",arguments,d->name);
+/* INTERNAL_ERROR_EXCL_START */
+		MesPrint("!>Could not read rhs %s in file %s\n",arguments,d->name);
 		M_free(buffer1,"tb,ReadObject");
 #ifdef WITHZLIB
 		if ( buffer2 ) M_free(buffer2,"tb,ReadObject");
 #endif
 		return(0);
+/* INTERNAL_ERROR_EXCL_STOP */
 	}
 #ifdef WITHZLIB
 	if ( buffer2 == 0 ) return(buffer1);
 	finallength = obj->uncompressed;
 	if ( uncompress((Bytef *)buffer2,&finallength,(Bytef *)buffer1,obj->size) != Z_OK ) {
-		MesPrint("Cannot uncompress element %s in file %s\n",arguments,d->name);
+/* INTERNAL_ERROR_EXCL_START */
+		MesPrint("!>Cannot uncompress element %s in file %s\n",arguments,d->name);
 		M_free(buffer1,"tb,ReadObject"); M_free(buffer2,"tb,ReadObject");
 		return(0);
+/* INTERNAL_ERROR_EXCL_STOP */
 	}
 	M_free(buffer1,"tb,ReadObject");
 	return(buffer2);
@@ -1396,21 +1454,25 @@ char *ReadijObject(DBASE *d,MLONG i,MLONG j,char *arguments)
 	else buffer2 = 0;
 #endif
 	if ( minosread(d->handle,buffer1,obj->size) ) {
-		MesPrint("Could not read rhs %s in file %s\n",arguments,d->name);
+/* INTERNAL_ERROR_EXCL_START */
+		MesPrint("!>Could not read rhs %s in file %s\n",arguments,d->name);
 		if ( buffer1 ) M_free(buffer1,"rhs buffer1");
 #ifdef WITHZLIB
 		if ( buffer2 ) M_free(buffer2,"rhs buffer2");
 #endif
 		return(0);
+/* INTERNAL_ERROR_EXCL_STOP */
 	}
 #ifdef WITHZLIB
 	if ( buffer2 == 0 ) return(buffer1);
 	finallength = obj->uncompressed;
 	if ( uncompress((Bytef *)buffer2,&finallength,(Bytef *)buffer1,obj->size) != Z_OK ) {
-		MesPrint("Cannot uncompress element %s in file %s\n",arguments,d->name);
+/* INTERNAL_ERROR_EXCL_START */
+		MesPrint("!>Cannot uncompress element %s in file %s\n",arguments,d->name);
 		if ( buffer1 ) M_free(buffer1,"rhs buffer1");
 		if ( buffer2 ) M_free(buffer2,"rhs buffer2");
 		return(0);
+/* INTERNAL_ERROR_EXCL_STOP */
 	}
 	M_free(buffer1,"rhs buffer1");
 	return(buffer2);

--- a/sources/module.c
+++ b/sources/module.c
@@ -379,8 +379,10 @@ void FullCleanUp(void)
 
 	NumExpressions = 0;
 	if ( DeleteStore(0) < 0 ) {
-		MesPrint("@Cannot restart the storage file");
+/* INTERNAL_ERROR_EXCL_START */
+		MesPrint("!>Cannot restart the storage file");
 		Terminate(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 	}
 	RemoveDollars();
 	CleanUp(1);

--- a/sources/names.c
+++ b/sources/names.c
@@ -230,9 +230,11 @@ int AddName(NAMETREE *nametree, UBYTE *name, WORD type, WORD number, int *nodenu
 	}
 #ifdef DEBUGON
 	else {	/* Cannot be. Code here for debugging only */
-		MesPrint("We ran into an impossible case in AddName\n");
+/* INTERNAL_ERROR_EXCL_START */
+		MesPrint("!>We ran into an impossible case in AddName\n");
 		DumpTree(nametree);
 		Terminate(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 	}
 #endif
 	return(retval);
@@ -764,8 +766,10 @@ void CopyTree(NAMETREE *newtree, NAMETREE *oldtree, WORD node, WORD par)
 				Dollars[n->number].node = newtree->nodefill;
 				break;
 			default:
-				MesPrint("Illegal variable type in CopyTree: %d",n->type);
+/* INTERNAL_ERROR_EXCL_START */
+				MesPrint("!>Illegal variable type in CopyTree: %d",n->type);
 				break;
+/* INTERNAL_ERROR_EXCL_STOP */
 		}
 		newtree->nodefill++;
 		s = newtree->namebuffer + newtree->namefill;

--- a/sources/normal.c
+++ b/sources/normal.c
@@ -2508,8 +2508,9 @@ NoInteg:;
 			default :
 defaultcase:;
 				if ( *t < FUNCTION ) {
+/* INTERNAL_ERROR_EXCL_START */
 					MLOCK(ErrorMessageLock);
-					MesPrint("Illegal code in Norm");
+					MesPrint("!>Illegal code in Norm");
 #ifdef DEBUGON
 					{
 						UBYTE OutBuf[140];
@@ -2528,6 +2529,7 @@ defaultcase:;
 #endif
 					MUNLOCK(ErrorMessageLock);
 					goto NormMin;
+/* INTERNAL_ERROR_EXCL_STOP */
 				}
 				if ( *t == REPLACEMENT ) {
 					if ( AR.Eside != LHSIDE ) ReplaceVeto--;
@@ -3699,10 +3701,12 @@ regularratfun:;
 								C->rhs[C->numrhs+1] = mm;
 								C->Pointer = mm;
 								if ( mm > C->Top ) {
+/* INTERNAL_ERROR_EXCL_START */
 									MLOCK(ErrorMessageLock);
-									MesPrint("Internal error in Normalize with extra compiler buffer");
+									MesPrint("!>Internal error in Normalize with extra compiler buffer");
 									MUNLOCK(ErrorMessageLock);
 									Terminate(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 								}
 								ma += 2 + ma[2];
 								continue;

--- a/sources/notation.c
+++ b/sources/notation.c
@@ -170,11 +170,13 @@ int NormPolyTerm(PHEAD WORD *term)
 				t += t[1];
 				break;
 			default:
+/* INTERNAL_ERROR_EXCL_START */
 				MLOCK(ErrorMessageLock);
-				MesPrint("Illegal code in NormPolyTerm");
+				MesPrint("!>Illegal code in NormPolyTerm");
 				MUNLOCK(ErrorMessageLock);
 				Terminate(-1);
 				break;
+/* INTERNAL_ERROR_EXCL_STOP */
 		}
 	}
 /*
@@ -481,10 +483,12 @@ int ConvertToPoly(PHEAD WORD *term, WORD *outterm, WORD *comlist, WORD par)
 	  i = action;
 	}
 	else {
+/* INTERNAL_ERROR_EXCL_START */
 		MLOCK(ErrorMessageLock);
-		MesPrint("Illegal internal code in conversion to polynomial notation");
+		MesPrint("!>Illegal internal code in conversion to polynomial notation");
 		MUNLOCK(ErrorMessageLock);
 		i = -1;
+/* INTERNAL_ERROR_EXCL_STOP */
 	}
 	return(i);
 }

--- a/sources/opera.c
+++ b/sources/opera.c
@@ -237,10 +237,12 @@ DoOnce:
 		tstop -= SUBEXPSIZE;
 		while ( t < tstop ) *m++ = *t++;
 		if ( t[2] != num || *t != SUBEXPRESSION ) {
+/* INTERNAL_ERROR_EXCL_START */
 			MLOCK(ErrorMessageLock);
-			MesPrint("Serious error in EpfCon");
+			MesPrint("!>Serious error in EpfCon");
 			MUNLOCK(ErrorMessageLock);
 			return(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 		}
 		tstop += SUBEXPSIZE;
 		if ( sizes ) {

--- a/sources/optimize.cc
+++ b/sources/optimize.cc
@@ -4454,14 +4454,18 @@ WORD generate_expression (WORD exprnr) {
 	SetScratch(AR.infile,&(e->onfile));
 
 	if ( GetTerm(BHEAD term) <= 0 ) {
-		MesPrint("Expression %d has problems in scratchfile",exprnr);
+/* INTERNAL_ERROR_EXCL_START */
+		MesPrint("!>Expression %d has problems in scratchfile",exprnr);
 		Terminate(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 	}
 	SeekScratch(AR.outfile,&position);
 	e->onfile = position;
 	if ( PutOut(BHEAD term,&position,AR.outfile,0) < 0 ) {
-		MesPrint("Expression %d has problems in output scratchfile",exprnr);
+/* INTERNAL_ERROR_EXCL_START */
+		MesPrint("!>Expression %d has problems in output scratchfile",exprnr);
 		Terminate(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 	}
 
 	AR.CurExpr = exprnr;
@@ -4994,8 +4998,10 @@ int ClearOptimize()
 		comexpr.c
 */
 		if ( GetName(AC.exprnames,AO.OptimizeResult.nameofexpr,&numexpr,NOAUTO) != CEXPRESSION ) {
-			MesPrint("@Internal error while clearing optimized expression %s ",AO.OptimizeResult.nameofexpr);
+/* INTERNAL_ERROR_EXCL_START */
+			MesPrint("!>Internal error while clearing optimized expression %s ",AO.OptimizeResult.nameofexpr);
 			Terminate(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 		}
 		M_free(AO.OptimizeResult.nameofexpr, "optimize expression name");
 		AO.OptimizeResult.nameofexpr = NULL;

--- a/sources/pattern.c
+++ b/sources/pattern.c
@@ -127,10 +127,12 @@ int TestMatch(PHEAD WORD *term, WORD *level)
 		else {
 			AN.RepPoint--;
 			if ( AN.RepPoint < AT.RepCount ) {
+/* INTERNAL_ERROR_EXCL_START */
 				MLOCK(ErrorMessageLock);
-				MesPrint("Internal problems with REPEAT count");
+				MesPrint("!>Internal problems with REPEAT count");
 				MUNLOCK(ErrorMessageLock);
 				Terminate(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 			}
 		}
 		return(0);			/* Force the next level */

--- a/sources/polygcd.cc
+++ b/sources/polygcd.cc
@@ -1623,9 +1623,11 @@ const poly polygcd::gcd (const poly &a, const poly &b) {
 		}
 
 		if (res.is_zero() || !poly::divides(res,ppa) || !poly::divides(res,ppb)) {
-			MesPrint("Bad gcd found.");
+/* INTERNAL_ERROR_EXCL_START */
+			MesPrint("!>Bad gcd found.");
 			std::cout << "Bad gcd:" << res << " for " << ppa << " " << ppb << std::endl;
 			Terminate(1);
+/* INTERNAL_ERROR_EXCL_STOP */
 		}
 	}
 

--- a/sources/polywrap.cc
+++ b/sources/polywrap.cc
@@ -275,10 +275,12 @@ WORD *poly_divmod(PHEAD WORD *a, WORD *b, int divmod, WORD fit) {
 				if(denompower < prevdenompower)
 				{
 					// denompower increased beyond INT_MAX
+/* INTERNAL_ERROR_EXCL_START */
 					MLOCK(ErrorMessageLock);
-					MesPrint ((char*)"ERROR: pseudo-division failed in poly_divmod (denompower > INT_MAX)");
+					MesPrint ((char*)"!>ERROR: pseudo-division failed in poly_divmod (denompower > INT_MAX)");
 					MUNLOCK(ErrorMessageLock);
 					Terminate(1);
+/* INTERNAL_ERROR_EXCL_STOP */
 				}
 
 				if(denompower != 0)
@@ -1228,8 +1230,10 @@ int poly_factorize_expression(EXPRESSIONS expr) {
 		pos = expr->onfile;
 		SeekFile(file->handle,&pos,SEEK_SET);
 		if (ISNOTEQUALPOS(pos,expr->onfile)) {
-			MesPrint("ERROR: something wrong in scratch file [poly_factorize_expression]");
+/* INTERNAL_ERROR_EXCL_START */
+			MesPrint("!>ERROR: something wrong in scratch file [poly_factorize_expression]");
 			Terminate(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 		}
 		file->POposition = expr->onfile;
 		file->POfull = file->PObuffer;
@@ -1247,8 +1251,10 @@ int poly_factorize_expression(EXPRESSIONS expr) {
 	// read the first header term
 	WORD size = GetTerm(BHEAD term);
 	if (size <= 0) {
-		MesPrint ("ERROR: something wrong with expression [poly_factorize_expression]");
+/* INTERNAL_ERROR_EXCL_START */
+		MesPrint ("!>ERROR: something wrong with expression [poly_factorize_expression]");
 		Terminate(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 	}
 
 	// store position: this is where the output will go
@@ -1270,8 +1276,10 @@ int poly_factorize_expression(EXPRESSIONS expr) {
 		}
 		buffer.check_memory(bufpos);		
 		if (LocalConvertToPoly(BHEAD term, buffer.terms + bufpos, startebuf,0) < 0) {
-			MesPrint("ERROR: in LocalConvertToPoly [factorize_expression]");
+/* INTERNAL_ERROR_EXCL_START */
+			MesPrint("!>ERROR: in LocalConvertToPoly [factorize_expression]");
 			Terminate(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 		}
 		bufpos += *(buffer.terms + bufpos);
 	}
@@ -1407,9 +1415,11 @@ int poly_factorize_expression(EXPRESSIONS expr) {
 						// substitute extra symbols
 						if (ConvertFromPoly(BHEAD t, term, numxsymbol, CC->numrhs-startebuf+numxsymbol,
 																startebuf-numxsymbol, 1) <= 0 ) {
-							MesPrint("ERROR: in ConvertFromPoly [factorize_expression]");
+/* INTERNAL_ERROR_EXCL_START */
+							MesPrint("!>ERROR: in ConvertFromPoly [factorize_expression]");
 							Terminate(-1);
 							return(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 						}
 						
 						// store term
@@ -1587,8 +1597,10 @@ int poly_unfactorize_expression(EXPRESSIONS expr)
 		pos = expr->onfile;
 		SeekFile(file->handle,&pos,SEEK_SET);
 		if (ISNOTEQUALPOS(pos,expr->onfile)) {
-			MesPrint("ERROR: something wrong in scratch file unfactorize_expression");
+/* INTERNAL_ERROR_EXCL_START */
+			MesPrint("!>ERROR: something wrong in scratch file unfactorize_expression");
 			Terminate(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 		}
 		file->POposition = expr->onfile;
 		file->POfull = file->PObuffer;
@@ -1614,8 +1626,10 @@ int poly_unfactorize_expression(EXPRESSIONS expr)
 */
 	size = GetTerm(BHEAD term);
 	if ( size <= 0 ) {
-		MesPrint ("ERROR: something wrong with expression unfactorize_expression");
+/* INTERNAL_ERROR_EXCL_START */
+		MesPrint ("!>ERROR: something wrong with expression unfactorize_expression");
 		Terminate(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 	}
 	pos = expr->onfile;
 	ADDPOS(pos, size*sizeof(WORD));

--- a/sources/pre.c
+++ b/sources/pre.c
@@ -2726,7 +2726,11 @@ int DoCall(UBYTE *s)
 	return(0);
 wrongfile:;
 	if ( i < 0 ) MesPrint("@File %s is not a proper procedure",p->name);
-	else MesPrint("!!!Internal error with procedure names: %s",name);
+	else {
+/* INTERNAL_ERROR_EXCL_START */
+		MesPrint("!>Internal error with procedure names: %s",name);
+/* INTERNAL_ERROR_EXCL_STOP */
+	}
 	return(-1);
 }
 
@@ -6965,8 +6969,10 @@ int DoOptimize(UBYTE *s)
 			AR.GetFile = 0;
 			SetScratch(AR.infile,&(e->onfile));
 			if ( GetTerm(BHEAD term) <= 0 ) {
-				MesPrint("@Expression %d has problems reading from scratchfile",i);
+/* INTERNAL_ERROR_EXCL_START */
+				MesPrint("!>Expression %d has problems reading from scratchfile",i);
 				Terminate(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 			}
 			term[3] = i;
 			AR.DeferFlag = 0;
@@ -6994,8 +7000,10 @@ int DoOptimize(UBYTE *s)
 			} while ( GetTerm(BHEAD term) );
 			if ( FlushOut(&position,AR.outfile,1) ) {
 DoSerr:
-				MesPrint("@Expression %d has problems writing to scratchfile",i);
+/* INTERNAL_ERROR_EXCL_START */
+				MesPrint("!>Expression %d has problems writing to scratchfile",i);
 				Terminate(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 			}
 #ifdef WITHMPI
 			}
@@ -7554,9 +7562,11 @@ UBYTE *ConstructName(UBYTE *s,UBYTE type)
 			*t = 0;
 			break;
 		default:
-			MesPrint("&Unrecognized datatype in ConstructName");
+/* INTERNAL_ERROR_EXCL_START */
+			MesPrint("!>Unrecognized datatype in ConstructName");
 			*t = 0;
 			break;
+/* INTERNAL_ERROR_EXCL_STOP */
 	}
 	return(AP.fullname);
 }

--- a/sources/proces.c
+++ b/sources/proces.c
@@ -218,9 +218,11 @@ int Processor(void)
 			AR.GetFile = 0;
 			SetScratch(AR.infile,&(e->onfile));
 			if ( GetTerm(BHEAD term) <= 0 ) {
-				MesPrint("(1) Expression %d has problems in scratchfile",i);
+/* INTERNAL_ERROR_EXCL_START */
+				MesPrint("!>(1) Expression %d has problems in scratchfile",i);
 				retval = -1;
 				break;
+/* INTERNAL_ERROR_EXCL_STOP */
 			}
 			term[3] = i;
 			AR.CurExpr = i;
@@ -327,9 +329,11 @@ commonread:;
 					MesPrint("Error condition 1a");
 					ExprStatus(e);
 #endif
-					MesPrint("(2) Expression %d has problems in scratchfile(process)",i);
+/* INTERNAL_ERROR_EXCL_START */
+					MesPrint("!>(2) Expression %d has problems in scratchfile(process)",i);
 					retval = -1;
 					break;
+/* INTERNAL_ERROR_EXCL_STOP */
 				}
 				term[3] = i;
 				if ( term[5] < 0 ) {	/* Fill with spectator */
@@ -359,8 +363,10 @@ commonread:;
 #ifdef WITHPTHREADS
 				if ( AS.MultiThreaded && AC.mparallelflag == PARALLELFLAG ) {
 					if ( ThreadsProcessor(e,LastExpression,fromspectator) ) {
-						MesPrint("Error in ThreadsProcessor");
+/* INTERNAL_ERROR_EXCL_START */
+						MesPrint("!>Error in ThreadsProcessor");
 						goto ProcErr;
+/* INTERNAL_ERROR_EXCL_STOP */
 					}
 					if ( AR.outtohide ) {
 						AR.outfile = oldoutfile;
@@ -487,9 +493,11 @@ commonread:;
 					MesPrint("Error condition 1b");
 					ExprStatus(e);
 #endif
-					MesPrint("(3) Expression %d has problems in scratchfile",i);
+/* INTERNAL_ERROR_EXCL_START */
+					MesPrint("!>(3) Expression %d has problems in scratchfile",i);
 					retval = -1;
 					break;
+/* INTERNAL_ERROR_EXCL_STOP */
 				}
 				term[3] = i;
 				AR.DeferFlag = 0;
@@ -530,9 +538,11 @@ commonread:;
 					MesPrint("Error condition 1c");
 					ExprStatus(e);
 #endif
-					MesPrint("(4) Expression %d has problems in scratchfile",i);
+/* INTERNAL_ERROR_EXCL_START */
+					MesPrint("!>(4) Expression %d has problems in scratchfile",i);
 					retval = -1;
 					break;
+/* INTERNAL_ERROR_EXCL_STOP */
 				}
 				term[3] = i;
 				AR.DeferFlag = 0;
@@ -826,10 +836,12 @@ ReStart:
 							We will generate more terms than we can count
 */
 TooMuch:;
+/* INTERNAL_ERROR_EXCL_START */
 							MLOCK(ErrorMessageLock);
-							MesPrint("Attempt to generate more terms than FORM can count");
+							MesPrint("!>Attempt to generate more terms than FORM can count");
 							MUNLOCK(ErrorMessageLock);
 							Terminate(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 						}
 						GetBinom(AN.BinoScrat,&AN.nbino,(WORD)mm,t[3]);
 						if ( AN.nbino > 2 ) goto TooMuch;
@@ -960,10 +972,12 @@ TooMuch:;
 						m = AT.WorkPointer;
 						AT.WorkPointer = m + *m;
 						if ( Normalize(BHEAD m) ) {
+/* INTERNAL_ERROR_EXCL_START */
 							MLOCK(ErrorMessageLock);
-							MesPrint("Error while picking up contents of bracket");
+							MesPrint("!>Error while picking up contents of bracket");
 							MUNLOCK(ErrorMessageLock);
 							Terminate(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 						}
 						if ( !*m ) {
 							*m++ = 4; *m++ = 1; *m++ = 1; *m++ = 3;
@@ -2675,8 +2689,9 @@ wrongtype:;
 		}
 		t += t[1];
 	}
+/* INTERNAL_ERROR_EXCL_START */
 	MLOCK(ErrorMessageLock);
-	MesPrint("Internal error in InFunction: Function not encountered.");
+	MesPrint("!>Internal error in InFunction: Function not encountered.");
 	if ( AM.tracebackflag ) {
 		MesPrint("%w: AR.TePos = %d",AR.TePos);
 		MesPrint("%w: AN.TeInFun = %d",AN.TeInFun);
@@ -2695,6 +2710,7 @@ wrongtype:;
 	}
 	MUNLOCK(ErrorMessageLock);
 	return(1);
+/* INTERNAL_ERROR_EXCL_STOP */
 
 InFunc:
 	MLOCK(ErrorMessageLock);
@@ -2948,10 +2964,12 @@ LONG PasteFile(PHEAD WORD number, WORD *accum, POSITION *position, WORD **accfil
 	}
 	accum += l;
 	if ( accum > stop ) {
+/* INTERNAL_ERROR_EXCL_START */
 		MLOCK(ErrorMessageLock);
-		MesPrint("Buffer too small in PasteFile");
+		MesPrint("!>Buffer too small in PasteFile");
 		MUNLOCK(ErrorMessageLock);
 		SETERROR(-1)
+/* INTERNAL_ERROR_EXCL_STOP */
 	}
 	*accum = 0;
 	*accfill = accum;
@@ -3029,10 +3047,12 @@ WORD *PasteTerm(PHEAD WORD number, WORD *accum, WORD *position, WORD times, WORD
 		*u = WORDDIF(accum,u);
 	}
 	if ( accum >= m ) {
+/* INTERNAL_ERROR_EXCL_START */
 		MLOCK(ErrorMessageLock);
-		MesPrint("Buffer too small in PasteTerm");
+		MesPrint("!>Buffer too small in PasteTerm");
 		MUNLOCK(ErrorMessageLock);
 		return(0);
+/* INTERNAL_ERROR_EXCL_STOP */
 	}
 	*accum = 0;
 	return(accum);
@@ -4174,7 +4194,9 @@ AutoGen:	i = *AT.TMout;
 							MesPrint("Attempt to use factor %d of an unfactored $-variable",(WORD)(AT.TMdolfac-1));
 						}
 						else {
-							MesPrint("Internal error. Illegal number of factors for $-variable");
+/* INTERNAL_ERROR_EXCL_START */
+							MesPrint("!>Internal error. Illegal number of factors for $-variable");
+/* INTERNAL_ERROR_EXCL_STOP */
 						}
 						MUNLOCK(ErrorMessageLock);
 						goto GenCall;
@@ -4807,9 +4829,11 @@ EndExpr:
 		SeekFile(fi->handle,&oldposition,SEEK_SET);
 		UNLOCK(AS.inputslock);
 		if ( ISNEGPOS(oldposition) ) {
+/* INTERNAL_ERROR_EXCL_START */
 			MLOCK(ErrorMessageLock);
-			MesPrint("File error");
+			MesPrint("!>File error");
 			goto PowCall2;
+/* INTERNAL_ERROR_EXCL_STOP */
 		}
 #endif
 	}
@@ -5333,11 +5357,13 @@ int PrepPoly(PHEAD WORD *term,WORD par)
 */
 	}
 	else {
+/* INTERNAL_ERROR_EXCL_START */
 		DoError:;
 		MLOCK(ErrorMessageLock);
-		MesPrint("Illegal value for PolyFunType in PrepPoly");
+		MesPrint("!>Illegal value for PolyFunType in PrepPoly");
 		MUNLOCK(ErrorMessageLock);
 		Terminate(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 	}
 	r = term + *term;
 	AT.PolyAct = WORDDIF(poly,term);
@@ -5398,11 +5424,13 @@ SkipFun:
 			}
 			else {
 NoLegal:
+/* INTERNAL_ERROR_EXCL_START */
 				MLOCK(ErrorMessageLock);
-				MesPrint("Illegal term with divergence in PolyRatFun");
+				MesPrint("!>Illegal term with divergence in PolyRatFun");
 				MesCall("PolyFunMul");
 				MUNLOCK(ErrorMessageLock);
 				Terminate(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 			}
 			if ( *t < 0 ) {
 				if ( *t == -SYMBOL && t[1] == AR.PolyFunVar ) pow1--;
@@ -5665,8 +5693,10 @@ retry:
 					if ( t1[4] < minp1 ) minp1 = t1[4];
 				}
 				else {
-					MesPrint("Illegal term in expanded polyratfun.");
+/* INTERNAL_ERROR_EXCL_START */
+					MesPrint("!>Illegal term in expanded polyratfun.");
 					goto PolyCall;
+/* INTERNAL_ERROR_EXCL_STOP */
 				}
 			}
 		}
@@ -5683,8 +5713,10 @@ retry:
 					if ( t2[4] < minp2 ) minp2 = t2[4];
 				}
 				else {
-					MesPrint("Illegal term in expanded polyratfun.");
+/* INTERNAL_ERROR_EXCL_START */
+					MesPrint("!>Illegal term in expanded polyratfun.");
 					goto PolyCall;
+/* INTERNAL_ERROR_EXCL_STOP */
 				}
 			}
 		}

--- a/sources/ratio.c
+++ b/sources/ratio.c
@@ -644,10 +644,12 @@ int GCDfunction(PHEAD WORD *term,WORD level)
 		t += t[1];
 	}
 	if ( t >= tstop ) {
+/* INTERNAL_ERROR_EXCL_START */
 		MLOCK(ErrorMessageLock);
-		MesPrint("Internal error. Indicated gcd_ function not encountered.");
+		MesPrint("!>Internal error. Indicated gcd_ function not encountered.");
 		MUNLOCK(ErrorMessageLock);
 		Terminate(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 	}
 	WantAddPointers(totargs);
 	args = AT.pWorkPointer; AT.pWorkPointer += totargs;
@@ -769,10 +771,12 @@ doshort:
 			goto gcdone;
 		}
 		else {
+/* INTERNAL_ERROR_EXCL_START */
 			MLOCK(ErrorMessageLock);
-			MesPrint("Internal error. Illegal short argument in GCDfunction.");
+			MesPrint("!>Internal error. Illegal short argument in GCDfunction.");
 			MUNLOCK(ErrorMessageLock);
 			Terminate(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 		}
 	}
 /*
@@ -990,10 +994,12 @@ oneterm:;
 			abuf[i].size = m-abuf[i].buffer;
 		}
 		else {
+/* INTERNAL_ERROR_EXCL_START */
 			MLOCK(ErrorMessageLock);
-			MesPrint("What argument is this?");
+			MesPrint("!>What argument is this?");
 			MUNLOCK(ErrorMessageLock);
 			goto CalledFrom;
+/* INTERNAL_ERROR_EXCL_STOP */
 		}
 	}
 	for ( i = 0; i < numargs; i++ ) {
@@ -2458,11 +2464,13 @@ int FromPolyRatFun(PHEAD WORD *fun, WORD **numout, WORD **denout)
 	AT.WorkPointer = tt;
 	return(0);
 Improper:
+/* INTERNAL_ERROR_EXCL_START */
 	MLOCK(ErrorMessageLock);
-	MesPrint("Improper use of PolyRatFun");
+	MesPrint("!>Improper use of PolyRatFun");
 	MesCall("FromPolyRatFun");
 	MUNLOCK(ErrorMessageLock);
 	SETERROR(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 }
 
 /*
@@ -2846,10 +2854,12 @@ int DIVfunction(PHEAD WORD *term,WORD level,int par)
 	WORD startebuf = cbuf[AT.ebufnum].numrhs;
 	int division = ( par <= 2 );  /* false for mul_ */
 	if ( par < 0 || par > 3 ) {
+/* INTERNAL_ERROR_EXCL_START */
 		MLOCK(ErrorMessageLock);
-		MesPrint("Internal error. Illegal parameter %d in DIVfunction.",par);
+		MesPrint("!>Internal error. Illegal parameter %d in DIVfunction.",par);
 		MUNLOCK(ErrorMessageLock);
 		Terminate(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 	}
 /*
 	Find the function
@@ -2872,10 +2882,12 @@ int DIVfunction(PHEAD WORD *term,WORD level,int par)
 		t = tt;
 	}
 	if ( t >= tstop ) {
+/* INTERNAL_ERROR_EXCL_START */
 		MLOCK(ErrorMessageLock);
-		MesPrint("Internal error. Indicated div_ or rem_ function not encountered.");
+		MesPrint("!>Internal error. Indicated div_ or rem_ function not encountered.");
 		MUNLOCK(ErrorMessageLock);
 		Terminate(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 	}
 /*
 	We have two arguments in arg1 and arg2.
@@ -3029,13 +3041,15 @@ WORD *MULfunc(PHEAD WORD *p1, WORD *p2)
 			else               sign2 = 1;
 			size2 = (size2-1)/2;
 			if ( MulLong(num1,size1,num2,size2,num3,&size3) ) {
+/* INTERNAL_ERROR_EXCL_START */
 				error = 1;
 CalledFrom:
 				MLOCK(ErrorMessageLock);
-				MesPrint(" Error %d",error);
+				MesPrint("!>Error %d",error);
 				MesCall("MulFunc");
 				MUNLOCK(ErrorMessageLock);
 				Terminate(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 			}
 			tfill = prod+1;
 			t = p1+1; while ( t < (WORD *)num1 ) *tfill++ = *t++;

--- a/sources/reken.c
+++ b/sources/reken.c
@@ -64,16 +64,20 @@ void Pack(UWORD *a, WORD *na, UWORD *b, WORD nb)
 	WORD c, sgn = 1, i;
 	UWORD *to,*from;
 	if ( (c = *na) == 0 ) {
+/* INTERNAL_ERROR_EXCL_START */
 		MLOCK(ErrorMessageLock);
-		MesPrint("Caught a zero in Pack");
+		MesPrint("!>Caught a zero in Pack");
 		MUNLOCK(ErrorMessageLock);
 		return;
+/* INTERNAL_ERROR_EXCL_STOP */
 	}
 	if ( nb == 0 ) {
+/* INTERNAL_ERROR_EXCL_START */
 		MLOCK(ErrorMessageLock);
-		MesPrint("Division by zero in Pack");
+		MesPrint("!>Division by zero in Pack");
 		MUNLOCK(ErrorMessageLock);
 		return;
+/* INTERNAL_ERROR_EXCL_STOP */
 	}
 	if ( *na < 0 ) { sgn = -sgn; c = -c; }
 	if ( nb < 0 ) { sgn = -sgn; nb = -nb; }
@@ -176,10 +180,12 @@ int Divvy(PHEAD UWORD *a, WORD *na, UWORD *b, WORD nb)
 	WORD i, sgn = 1;
 	WORD nd, ne, adenom, anumer;
 	if ( !nb ) {
+/* INTERNAL_ERROR_EXCL_START */
 		MLOCK(ErrorMessageLock);
-		MesPrint("Division by zero in Divvy");
+		MesPrint("!>Division by zero in Divvy");
 		MUNLOCK(ErrorMessageLock);
 		return(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 	}
 	d = NumberMalloc("Divvy"); e = NumberMalloc("Divvy");
 	if ( nb < 0 ) { sgn = -sgn; nb = -nb; }
@@ -504,10 +510,12 @@ int DivRat(PHEAD UWORD *a, WORD na, UWORD *b, WORD nb, UWORD *c, WORD *nc)
 	int ret;
 	UWORD *xd,*xe,xx;
 	if ( !nb ) {
+/* INTERNAL_ERROR_EXCL_START */
 		MLOCK(ErrorMessageLock);
-		MesPrint("Rational division by zero");
+		MesPrint("!>Rational division by zero");
 		MUNLOCK(ErrorMessageLock);
 		return(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 	}
 	j = i = (nb >= 0)? nb: -nb;
 	xd = b; xe = b + i;
@@ -1156,8 +1164,9 @@ int DivLong(UWORD *a, WORD na, UWORD *b, WORD nb, UWORD *c,
 					estim++;
 					SubPLon(f+ni,nh,e,ne,f+ni,&nh);
 					if ( BigLong(f+ni,nh,e,ne) >= 0 ) {
+/* INTERNAL_ERROR_EXCL_START */
 						MLOCK(ErrorMessageLock);
-						MesPrint("Problems in DivLong");
+						MesPrint("!>Problems in DivLong");
 						AO.OutSkip = 3;
 						FiniLine();
 						i = na;
@@ -1170,6 +1179,7 @@ int DivLong(UWORD *a, WORD na, UWORD *b, WORD nb, UWORD *c,
 						MUNLOCK(ErrorMessageLock);
 						NumberFree(e,"DivLong"); NumberFree(f,"DivLong"); NumberFree(g,"DivLong");
 						return(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 					}
 				}
 			}
@@ -1201,11 +1211,13 @@ int DivLong(UWORD *a, WORD na, UWORD *b, WORD nb, UWORD *c,
 					}
 				}
 				if ( t ) {
+/* INTERNAL_ERROR_EXCL_START */
 					MLOCK(ErrorMessageLock);
-					MesPrint("Error in DivLong");
+					MesPrint("!>Error in DivLong");
 					MUNLOCK(ErrorMessageLock);
 					NumberFree(e,"DivLong"); NumberFree(f,"DivLong"); NumberFree(g,"DivLong");
 					return(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 				}
 				if ( !*(d+nh-1) ) (*nd)--;
 			}
@@ -1496,10 +1508,12 @@ int GetModInverses(WORD m1, WORD m2, WORD *im1, WORD *im2)
 	if (im2!=NULL) *im2 = b2;
 	return(0);
 somethingwrong:
+/* INTERNAL_ERROR_EXCL_START */
 	MLOCK(ErrorMessageLock);
-	MesPrint("Error trying to determine inverses in GetModInverses");
+	MesPrint("!>Error trying to determine inverses in GetModInverses");
 	MUNLOCK(ErrorMessageLock);
 	return(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 }
 /*
  		#] GetModInverses : 
@@ -1994,10 +2008,12 @@ int GcdLong(PHEAD UWORD *a, WORD na, UWORD *b, WORD nb, UWORD *c, WORD *nc)
 	GETBIDENTITY
 	if ( !na || !nb ) {
 		if ( !na && !nb ) {
+/* INTERNAL_ERROR_EXCL_START */
 			MLOCK(ErrorMessageLock);
-			MesPrint("Cannot take gcd");
+			MesPrint("!>Cannot take gcd");
 			MUNLOCK(ErrorMessageLock);
 			return(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 		}
 		
 		if ( !na ) {
@@ -2285,10 +2301,12 @@ int GcdLong(PHEAD UWORD *a, WORD na, UWORD *b, WORD nb, UWORD *c, WORD *nc)
 	LONG ma1, ma2, mb1, mb2, mc1, mc2, m;
 	if ( !na || !nb ) {
 		if ( !na && !nb ) {
+/* INTERNAL_ERROR_EXCL_START */
 			MLOCK(ErrorMessageLock);
-			MesPrint("Cannot take gcd");
+			MesPrint("!>Cannot take gcd");
 			MUNLOCK(ErrorMessageLock);
 			return(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 		}
 		
 		if ( !na ) {
@@ -3370,10 +3388,12 @@ int MakeModTable(void)
 		AC.modpowers = NULL;
 	}
 	if ( n > 2 ) {
+/* INTERNAL_ERROR_EXCL_START */
 		MLOCK(ErrorMessageLock);
-		MesPrint("&No memory for modulus generator power table");
+		MesPrint("!>No memory for modulus generator power table");
 		MUNLOCK(ErrorMessageLock);
 		Terminate(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 	}
 	if ( n == 0 ) return(0);
 	size = (LONG)(*AC.cmod);
@@ -3705,12 +3725,14 @@ WORD NextPrime(PHEAD WORD num)
 nexti:;
 			}
 			if ( i < MAXPOWER ) {
+/* INTERNAL_ERROR_EXCL_START */
 				MLOCK(ErrorMessageLock);
-				MesPrint("There are not enough short prime numbers for this calculation");
+				MesPrint("!>There are not enough short prime numbers for this calculation");
 				MesPrint("Try to use a computer with a %d-bits architecture",
 					(int)(BITSINWORD*4));
 				MUNLOCK(ErrorMessageLock);
 				Terminate(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 			}
 		}
 	}

--- a/sources/reshuf.c
+++ b/sources/reshuf.c
@@ -184,10 +184,12 @@ void FunLevel(PHEAD WORD *term)
 				break;
 			default:
 				if ( *t < FUNCTION ) {
+/* INTERNAL_ERROR_EXCL_START */
 				  MLOCK(ErrorMessageLock);
-				  MesPrint("Unexpected code in ReNumber");
+				  MesPrint("!>Unexpected code in ReNumber");
 				  MUNLOCK(ErrorMessageLock);
 				  Terminate(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 				}
 				fun = t+2;
 				if ( *t >= FUNCTION && functions[*t-FUNCTION].spec
@@ -1415,10 +1417,12 @@ int DoDelta3(PHEAD WORD *term, WORD level)
 	while ( ( *t != DELTA3 || ((t[1]-FUNHEAD) & 1 ) != 0 ) && t < stopper )
 		t += t[1];
 	if ( t >= stopper ) {
+/* INTERNAL_ERROR_EXCL_START */
 		MLOCK(ErrorMessageLock);
-		MesPrint("Internal error with dd_ function");
+		MesPrint("!>Internal error with dd_ function");
 		MUNLOCK(ErrorMessageLock);
 		Terminate(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 	}
 	m1 = t; m2 = t + t[1];
 	num = t[1] - FUNHEAD;
@@ -3089,10 +3093,12 @@ WORD *StuffRootAdd(WORD *t1, WORD *t2, WORD *to)
 */
 DoCoeffi:
 			if ( AddLong((UWORD *)tt1,size1,(UWORD *)tt2,size2,(UWORD *)to,&size3) ) {
+/* INTERNAL_ERROR_EXCL_START */
 				MLOCK(ErrorMessageLock);
-				MesPrint("Called from StuffRootAdd");
+				MesPrint("!>Called from StuffRootAdd");
 				MUNLOCK(ErrorMessageLock);
 				Terminate(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 			}
 			sgn = sgn1*sgn2*sgn3;
 			if ( nosymbols && size3 == 1 ) {

--- a/sources/sch.c
+++ b/sources/sch.c
@@ -1497,8 +1497,10 @@ void WriteArgument(WORD *t)
 /*		StrCopy(VARNAME(functions,-*t-FUNCTION),Out); */
 	}
 	else {
-		MesPrint("Illegal function argument while writing");
+/* INTERNAL_ERROR_EXCL_START */
+		MesPrint("!>Illegal function argument while writing");
 		goto CleanUp;
+/* INTERNAL_ERROR_EXCL_STOP */
 	}
 	TokenToLine(buffer);
 CleanUp:
@@ -1828,7 +1830,9 @@ int WriteSubTerm(WORD *sterm, WORD first)
 				if ( first ) TokenToLine((UBYTE *)" ");
 			}
 			if ( *sterm < FUNCTION ) {
-			return(MesPrint("Illegal subterm while writing"));
+/* INTERNAL_ERROR_EXCL_START */
+			return(MesPrint("!>Illegal subterm while writing"));
+/* INTERNAL_ERROR_EXCL_STOP */
 			}
 			if ( !first ) MultiplyToLine();
 			first = 1;
@@ -2787,8 +2791,10 @@ int WriteOne(UBYTE *name, int alreadyinline, int nosemi, WORD plus)
 	if ( AC.OutputMode == FORTRANMODE || AC.OutputMode == PFORTRANMODE )
 			 AO.OutSkip = 6;
 	if ( GetTerm(BHEAD AO.termbuf) <= 0 ) {
-		MesPrint("@ReadError in expression %s",name);
+/* INTERNAL_ERROR_EXCL_START */
+		MesPrint("!>ReadError in expression %s",name);
 		goto AboWrite;
+/* INTERNAL_ERROR_EXCL_STOP */
 	}
 /*
 	PutPreVar(AM.oldnumextrasymbols,

--- a/sources/sort.c
+++ b/sources/sort.c
@@ -740,11 +740,13 @@ LONG EndSort(PHEAD WORD *buffer, int par)
 						if ( AN.tryterm > 0 ) AN.tryterm = 0;
 						if ( ( retval = ReadFile(newout->handle,(UBYTE *)to,BASEPOSITION(newout->filesize)) ) !=
 								BASEPOSITION(newout->filesize) ) {
+/* INTERNAL_ERROR_EXCL_START */
 							MLOCK(ErrorMessageLock);
-							MesPrint("Error reading information for $ variable");
+							MesPrint("!>Error reading information for $ variable");
 							MUNLOCK(ErrorMessageLock);
 							M_free(to,"$-buffer reading");
 							retval = -1;
+/* INTERNAL_ERROR_EXCL_STOP */
 						}
 						else {
 							*((WORD **)buffer) = to;
@@ -776,10 +778,12 @@ TooLarge:
 							if ( to >= AT.WorkSpace && to < AT.WorkTop && to+j > AT.WorkTop )
 								goto WorkSpaceError;
 							if ( j > AM.MaxTer ) {
+/* INTERNAL_ERROR_EXCL_START */
 								MLOCK(ErrorMessageLock);
-								MesPrint("Encountered term of size: %d words.", j/(LONG)sizeof(WORD) );
+								MesPrint("!>Encountered term of size: %d words.", j/(LONG)sizeof(WORD) );
 								MUNLOCK(ErrorMessageLock);
 								goto TooLarge;
+/* INTERNAL_ERROR_EXCL_STOP */
 							}
 							NCOPY(to,t,j);
 							retval = to - buffer - 1;
@@ -979,11 +983,13 @@ RetRetval:
 				if ( AN.tryterm > 0 ) AN.tryterm = 0;
 				if ( ( retval = ReadFile(newout->handle,(UBYTE *)to,BASEPOSITION(position)) ) !=
 				BASEPOSITION(position) ) {
+/* INTERNAL_ERROR_EXCL_START */
 					MLOCK(ErrorMessageLock);
-					MesPrint("Error reading information for $ variable");
+					MesPrint("!>Error reading information for $ variable");
 					MUNLOCK(ErrorMessageLock);
 					M_free(to,"$-buffer reading");
 					retval = -1;
+/* INTERNAL_ERROR_EXCL_STOP */
 				}
 				else {
 					*((WORD **)buffer) = to;
@@ -1064,10 +1070,12 @@ LONG PutIn(FILEHANDLE *file, POSITION *position, WORD *buffer, WORD **take, int 
 	from = buffer + ( file->POsize * sizeof(UBYTE) )/sizeof(WORD);
 	i = from - *take;
 	if ( i*((LONG)(sizeof(WORD))) > AM.MaxTer ) {
+/* INTERNAL_ERROR_EXCL_START */
 		MLOCK(ErrorMessageLock);
-		MesPrint("Problems in PutIn");
+		MesPrint("!>Problems in PutIn");
 		MUNLOCK(ErrorMessageLock);
 		Terminate(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 	}
 	to = buffer;
 	while ( --i >= 0 ) *--to = *--from;
@@ -1075,11 +1083,13 @@ LONG PutIn(FILEHANDLE *file, POSITION *position, WORD *buffer, WORD **take, int 
 #ifdef WITHZLIB
 	if ( ( RetCode = FillInputGZIP(file,position,(UBYTE *)buffer
 									,file->POsize,npat) ) < 0 ) {
+/* INTERNAL_ERROR_EXCL_START */
 		MLOCK(ErrorMessageLock);
-		MesPrint("PutIn: We have RetCode = %x while reading %x bytes",
+		MesPrint("!>PutIn: We have RetCode = %x while reading %x bytes",
 			RetCode,file->POsize);
 		MUNLOCK(ErrorMessageLock);
 		Terminate(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 	}
 #else
 #ifdef ALLLOCK
@@ -1090,11 +1100,13 @@ LONG PutIn(FILEHANDLE *file, POSITION *position, WORD *buffer, WORD **take, int 
 #ifdef ALLLOCK
 		UNLOCK(file->pthreadslock);
 #endif
+/* INTERNAL_ERROR_EXCL_START */
 		MLOCK(ErrorMessageLock);
-		MesPrint("PutIn: We have RetCode = %x while reading %x bytes",
+		MesPrint("!>PutIn: We have RetCode = %x while reading %x bytes",
 			RetCode,file->POsize);
 		MUNLOCK(ErrorMessageLock);
 		Terminate(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 	}
 #ifdef ALLLOCK
 	UNLOCK(file->pthreadslock);
@@ -1304,11 +1316,13 @@ WORD PutOut(PHEAD WORD *term, POSITION *position, FILEHANDLE *fi, WORD ncomp)
 		if ( i < 0 ) {			/* Compressed term */
 			i = term[1] + 2;
 			if ( fi == AR.outfile || fi == AR.hidefile ) {
+/* INTERNAL_ERROR_EXCL_START */
 				MLOCK(ErrorMessageLock);
-				MesPrint("Ran into precompressed term");
+				MesPrint("!>Ran into precompressed term");
 				MUNLOCK(ErrorMessageLock);
 				Terminate(-1);
 				return(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 			}
 		}
 		else if ( !AR.NoCompress && ( ncomp > 0 ) && AR.sLevel <= 0 ) {	/* Must compress */
@@ -2300,10 +2314,12 @@ twogen:
 				i1 = REDLENG(i1);
 				i2 = REDLENG(i2);
 				if ( AddRat(BHEAD (UWORD *)t1,i1,(UWORD *)t2,i2,(UWORD *)m,&i) ) {
+/* INTERNAL_ERROR_EXCL_START */
 					MLOCK(ErrorMessageLock);
-					MesPrint("Addition of coefficients of PolyFun");
+					MesPrint("!>Addition of coefficients of PolyFun");
 					MUNLOCK(ErrorMessageLock);
 					Terminate(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 				}
 				if ( i == 0 ) {
 					m = mm;
@@ -3793,9 +3809,11 @@ ConMer:
 				m1 = m2 + *m2;
 			}
 			if ( length < 0 ) {
+/* INTERNAL_ERROR_EXCL_START */
 				MLOCK(ErrorMessageLock);
-				MesPrint("Readerror");
+				MesPrint("!>Readerror");
 				goto PatCall2;
+/* INTERNAL_ERROR_EXCL_STOP */
 			}
 #ifdef WITHPTHREADS
 			if ( AS.MasterSort && ( fout == AR.outfile ) && S == AT.S0 ) {
@@ -3818,9 +3836,11 @@ ConMer:
 				ADDPOS(S->SizeInFile[par],length/sizeof(WORD));
 			}
 			if ( length < 0 ) {
+/* INTERNAL_ERROR_EXCL_START */
 				MLOCK(ErrorMessageLock);
-				MesPrint("Readerror");
+				MesPrint("!>Readerror");
 				goto PatCall2;
+/* INTERNAL_ERROR_EXCL_STOP */
 			}
 #endif
 		}
@@ -4124,10 +4144,12 @@ NextTerm:
 		else
 #endif
 		if ( ( im = PutOut(BHEAD poin[k],&position,fout,1) ) < 0 ) {
+/* INTERNAL_ERROR_EXCL_START */
 			MLOCK(ErrorMessageLock);
-			MesPrint("Called from MergePatches with k = %d (stream %d)",k,S->ktoi[k]);
+			MesPrint("!>Called from MergePatches with k = %d (stream %d)",k,S->ktoi[k]);
 			MUNLOCK(ErrorMessageLock);
 			goto ReturnError;
+/* INTERNAL_ERROR_EXCL_STOP */
 		}
 		ADDPOS(S->SizeInFile[par],im);
 		goto NextTerm;
@@ -4176,10 +4198,12 @@ EndOfAll:
 				sizeof(POSITION)
 			  || (ULONG)ReadFile(fin->handle,(UBYTE *)S->iPatches,(LONG)((S->inNum)+1)
 					*sizeof(POSITION)) != ((S->inNum)+1)*sizeof(POSITION) ) {
+/* INTERNAL_ERROR_EXCL_START */
 				MLOCK(ErrorMessageLock);
-				MesPrint("Read error fourth stage sorting");
+				MesPrint("!>Read error fourth stage sorting");
 				MUNLOCK(ErrorMessageLock);
 				goto ReturnError;
+/* INTERNAL_ERROR_EXCL_STOP */
 			}
 			*rr = 0;
 #ifdef WITHZLIB
@@ -4544,10 +4568,12 @@ int SortWild(WORD *w, WORD nw)
 							if ( sv < stop && ( *sv == FROMSET
 							|| *sv == SETTONUM || *sv == LOADDOLLAR ) ) {
 								if ( s[2] != sv[2] ) {
+/* INTERNAL_ERROR_EXCL_START */
 									error = -1;
 									MLOCK(ErrorMessageLock);
-									MesPrint("&Wildcard set conflict");
+									MesPrint("!>Wildcard set conflict");
 									MUNLOCK(ErrorMessageLock);
+/* INTERNAL_ERROR_EXCL_STOP */
 								}
 							}
 							*v = -1;

--- a/sources/spectator.c
+++ b/sources/spectator.c
@@ -363,11 +363,13 @@ int PutInSpectator(WORD *term,WORD specnum)
 					PUTZERO(fi->POposition);
 				}
 				else {
+/* INTERNAL_ERROR_EXCL_START */
 					MLOCK(ErrorMessageLock);
-					MesPrint("Cannot create spectator file %s",fi->name);
+					MesPrint("!>Cannot create spectator file %s",fi->name);
 					MUNLOCK(ErrorMessageLock);
 					UNLOCK(fi->pthreadslock);
 					return(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 				}
 			}
 			SeekFile(fi->handle,&(sp->position),SEEK_SET);
@@ -427,10 +429,12 @@ void FlushSpectators(void)
 				fh->handle = (WORD)RetCode;
 			}
 			else {
+/* INTERNAL_ERROR_EXCL_START */
 				MLOCK(ErrorMessageLock);
-				MesPrint("Cannot create spectator file %s",fh->name);
+				MesPrint("!>Cannot create spectator file %s",fh->name);
 				MUNLOCK(ErrorMessageLock);
 				Terminate(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 			}
 			PUTZERO(sp->position);
 		}
@@ -619,10 +623,12 @@ FillBuffer:
 		SeekFile(fh->handle,&(sp->readpos),SEEK_SET);
 		InIn = ReadFile(fh->handle,(UBYTE *)(fh->PObuffer),fh->POsize);
 		if ( InIn < 0 || ( InIn & 1 ) ) {
+/* INTERNAL_ERROR_EXCL_START */
 			MLOCK(ErrorMessageLock);
-			MesPrint("Error reading information for %s spectator",sp->name);
+			MesPrint("!>Error reading information for %s spectator",sp->name);
 			MUNLOCK(ErrorMessageLock);
 			Terminate(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 		}
 		InIn /= sizeof(WORD);
 		if ( InIn == 0 ) { *term = 0; return(0); }
@@ -642,17 +648,21 @@ FillBuffer:
 			SeekFile(fh->handle,&(sp->readpos),SEEK_SET);
 			InIn = ReadFile(fh->handle,(UBYTE *)(fh->PObuffer),fh->POsize);
 			if ( InIn < 0 || ( InIn & 1 ) ) {
+/* INTERNAL_ERROR_EXCL_START */
 				MLOCK(ErrorMessageLock);
-				MesPrint("Error reading information for %s spectator",sp->name);
+				MesPrint("!>Error reading information for %s spectator",sp->name);
 				MUNLOCK(ErrorMessageLock);
 				Terminate(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 			}
 			InIn /= sizeof(WORD);
 			if ( InIn == 0 ) {
+/* INTERNAL_ERROR_EXCL_START */
 				MLOCK(ErrorMessageLock);
-				MesPrint("Reading incomplete information for %s spectator",sp->name);
+				MesPrint("!>Reading incomplete information for %s spectator",sp->name);
 				MUNLOCK(ErrorMessageLock);
 				Terminate(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 			}
 			SeekFile(fh->handle,&(sp->readpos),SEEK_CUR);
 			fh->POposition = sp->readpos;

--- a/sources/store.c
+++ b/sources/store.c
@@ -131,25 +131,31 @@ void SetScratch(FILEHANDLE *f, POSITION *position)
 		if ( f->handle < 0 ) {
 			if ( ISEQUALPOSINC(*position,f->POposition,
 				(f->POfull-f->PObuffer)*sizeof(WORD)) ) goto endpos;
-			MesPrint("Illegal position in SetScratch");
+/* INTERNAL_ERROR_EXCL_START */
+			MesPrint("!>Illegal position in SetScratch");
 			Terminate(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 		}
 		possize = *position;
 		LOCK(AS.inputslock);
 		SeekFile(f->handle,&possize,SEEK_SET);
 		if ( ISNOTEQUALPOS(possize,*position) ) {
+/* INTERNAL_ERROR_EXCL_START */
 			UNLOCK(AS.inputslock);
-			MesPrint("Cannot position file in SetScratch");
+			MesPrint("!>Cannot position file in SetScratch");
 			Terminate(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 		}
 #ifdef HIDEDEBUG
 			MesPrint("SetScratch1(%w): position = %12p, size = %l, address = %x",position,f->POsize,f->PObuffer);
 #endif
 		if ( ( size = ReadFile(f->handle,(UBYTE *)(f->PObuffer),f->POsize) ) < 0
 		|| ( size & 1 ) != 0 ) {
+/* INTERNAL_ERROR_EXCL_START */
 			UNLOCK(AS.inputslock);
-			MesPrint("Read error in SetScratch");
+			MesPrint("!>Read error in SetScratch");
 			Terminate(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 		}
 		UNLOCK(AS.inputslock);
 		if ( size == 0 ) {
@@ -203,11 +209,15 @@ int RevertScratch(void)
 		PUTZERO(scrpos);
 		SeekFile(AR.infile->handle,&scrpos,SEEK_SET);
 		if ( ISNOTZEROPOS(scrpos) ) {
-			return(MesPrint("Error with scratch output."));
+/* INTERNAL_ERROR_EXCL_START */
+			return(MesPrint("!>Error with scratch output."));
+/* INTERNAL_ERROR_EXCL_STOP */
 		}
 		if ( ( AR.InInBuf = ReadFile(AR.infile->handle,(UBYTE *)(AR.infile->PObuffer)
 			,AR.infile->POsize) ) < 0 || AR.InInBuf & 1 ) {
-			return(MesPrint("Error while reading from scratch file"));
+/* INTERNAL_ERROR_EXCL_START */
+			return(MesPrint("!>Error while reading from scratch file"));
+/* INTERNAL_ERROR_EXCL_STOP */
 		}
 		else {
 			AR.InInBuf /= TABLESIZE(WORD,UBYTE);
@@ -246,11 +256,15 @@ int ResetScratch(void)
 		PUTZERO(scrpos);
 		SeekFile(AR.outfile->handle,&scrpos,SEEK_SET);
 		if ( ISNOTZEROPOS(scrpos) ) {
-			return(MesPrint("Error with scratch output."));
+/* INTERNAL_ERROR_EXCL_START */
+			return(MesPrint("!>Error with scratch output."));
+/* INTERNAL_ERROR_EXCL_STOP */
 		}
 		if ( ( AR.InInBuf = ReadFile(AR.outfile->handle,(UBYTE *)(AR.outfile->PObuffer)
 		,AR.outfile->POsize) ) < 0 || AR.InInBuf & 1 ) {
-			return(MesPrint("Error while reading from scratch file"));
+/* INTERNAL_ERROR_EXCL_START */
+			return(MesPrint("!>Error while reading from scratch file"));
+/* INTERNAL_ERROR_EXCL_STOP */
 		}
 		else AR.InInBuf /= TABLESIZE(WORD,UBYTE);
 		AR.outfile->POfull = AR.outfile->PObuffer + AR.InInBuf;
@@ -279,11 +293,13 @@ int ReadFromScratch(FILEHANDLE *fi, POSITION *pos, UBYTE *buffer, POSITION *leng
 	else {
 		SeekFile(fi->handle,pos,SEEK_SET);
 		if ( ReadFile(fi->handle,buffer,l) != l ) {
+/* INTERNAL_ERROR_EXCL_START */
 			if ( fi == AR.hidefile )
-				MesPrint("Error reading from hide file.");
+				MesPrint("!>Error reading from hide file.");
 			else
-				MesPrint("Error reading from scratch file.");
+				MesPrint("!>Error reading from scratch file.");
 			return(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 		}
 	}
 	return(0);
@@ -480,9 +496,11 @@ int CoSave(UBYTE *inp)
 							if ( ISLESSPOS(scrpos,scrpos1) ) wSize = BASEPOSITION(scrpos);
 							if ( ReadFile(AR.StoreData.Handle,(UBYTE *)AT.WorkPointer,wSize)
 							!= wSize ) {
-								MesPrint("ReadError");
+/* INTERNAL_ERROR_EXCL_START */
+								MesPrint("!>ReadError");
 								error = -1;
 								goto EndSave;
+/* INTERNAL_ERROR_EXCL_STOP */
 							}
 							if ( WriteFile(AO.SaveData.Handle,(UBYTE *)AT.WorkPointer,wSize)
 							!= wSize ) goto SavWrt;
@@ -542,9 +560,11 @@ NextExpr:;
 			do {
 				if ( ISLESSPOS(scrpos,scrpos1) ) wSize = BASEPOSITION(scrpos);
 				if ( ReadFile(AR.StoreData.Handle,(UBYTE *)AT.WorkPointer,wSize) != wSize ) {
-					MesPrint("ReadError");
+/* INTERNAL_ERROR_EXCL_START */
+					MesPrint("!>ReadError");
 					error = -1;
 					goto EndSave;
+/* INTERNAL_ERROR_EXCL_STOP */
 				}
 				if ( WriteFile(AO.SaveData.Handle,(UBYTE *)AT.WorkPointer,wSize) != wSize )
 					goto SavWrt;
@@ -559,9 +579,11 @@ EndSave:
 	}
 	return(error);
 SavWrt:
-	MesPrint("WriteError");
+/* INTERNAL_ERROR_EXCL_START */
+	MesPrint("!>WriteError");
 	error = -1;
 	goto EndSave;
+/* INTERNAL_ERROR_EXCL_STOP */
 }
 
 /*
@@ -751,13 +773,17 @@ EndLoad:
 	SeekFile(AR.StoreData.Handle,&(AC.StoreFileSize),SEEK_END);
 	return(error);
 LoadWrt:
-	MesPrint("WriteError");
+/* INTERNAL_ERROR_EXCL_START */
+	MesPrint("!>WriteError");
 	error = -1;
 	goto EndLoad;
+/* INTERNAL_ERROR_EXCL_STOP */
 LoadRead:
-	MesPrint("ReadError");
+/* INTERNAL_ERROR_EXCL_START */
+	MesPrint("!>ReadError");
 	error = -1;
 	goto EndLoad;
+/* INTERNAL_ERROR_EXCL_STOP */
 }
 
 /*
@@ -963,7 +989,9 @@ int PutInStore(INDEXENTRY *ind, WORD num)
 	if ( WriteFile(AR.StoreData.Handle,(UBYTE *)(&AR.StoreData.Index),(LONG)sizeof(FILEINDEX))
 	== (LONG)sizeof(FILEINDEX) ) return(0);
 PutErrS:
-	return(MesPrint("File error"));
+/* INTERNAL_ERROR_EXCL_START */
+	return(MesPrint("!>File error"));
+/* INTERNAL_ERROR_EXCL_STOP */
 }
 
 /*
@@ -1233,9 +1261,11 @@ RegRet:;
 */
 	return(*from);
 GTerr:
-	MesPrint("Error while reading scratch file in GetTerm");
+/* INTERNAL_ERROR_EXCL_START */
+	MesPrint("!>Error while reading scratch file in GetTerm");
 	Terminate(-1);
 	return(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 }
 
 /*
@@ -1403,11 +1433,13 @@ WORD GetOneTerm(PHEAD WORD *term, FILEHANDLE *fi, POSITION *pos, int par)
 		error = 6;
 	}
 ErrGet:
+/* INTERNAL_ERROR_EXCL_START */
 	MLOCK(ErrorMessageLock);
-	MesPrint("Error while reading scratch file in GetOneTerm (%d)",error);
+	MesPrint("!>Error while reading scratch file in GetOneTerm (%d)",error);
 	MUNLOCK(ErrorMessageLock);
 	Terminate(-1);
 	return(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 }
 
 /*
@@ -1760,10 +1792,12 @@ InNew:
 		SeekFile(AR.StoreData.Handle,position,SEEK_CUR);
 		UNLOCK(AM.storefilelock);
 		if ( RetCode != sizeof(WORD) ) {
+/* INTERNAL_ERROR_EXCL_START */
 			MLOCK(ErrorMessageLock);
-			MesPrint("@Error in compression of store file");
+			MesPrint("!>Error in compression of store file");
 			MUNLOCK(ErrorMessageLock);
 			return(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 		}
 		num = *m;
 		*to += (WORD)num;
@@ -1776,10 +1810,12 @@ InNew:
 	first = num;
 	num *= wsizeof(WORD);
 	if ( num < 0 ) {
+/* INTERNAL_ERROR_EXCL_START */
 		MLOCK(ErrorMessageLock);
-		MesPrint("@Error in stored expressions file at position %9p",position);
+		MesPrint("!>Error in stored expressions file at position %9p",position);
 		MUNLOCK(ErrorMessageLock);
 		return(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 	}
 	LOCK(AM.storefilelock);
 	SeekFile(AR.StoreData.Handle,position,SEEK_SET);
@@ -1787,10 +1823,12 @@ InNew:
 	SeekFile(AR.StoreData.Handle,position,SEEK_CUR);
 	UNLOCK(AM.storefilelock);
 	if ( RetCode != num ) {
+/* INTERNAL_ERROR_EXCL_START */
 		MLOCK(ErrorMessageLock);
-		MesPrint("@Error in stored expressions file at position %9p",position);
+		MesPrint("!>Error in stored expressions file at position %9p",position);
 		MUNLOCK(ErrorMessageLock);
 		return(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 	}
 	NCOPY(r,m,first);
 PastEnd:
@@ -1809,10 +1847,12 @@ PastEnd:
 		return((WORD)*to);
 	}
 PastErr:
+/* INTERNAL_ERROR_EXCL_START */
 	MLOCK(ErrorMessageLock);
-	MesCall("GetFromStore");
+	MesCall("!>GetFromStore");
 	MUNLOCK(ErrorMessageLock);
 	SETERROR(-1)
+/* INTERNAL_ERROR_EXCL_STOP */
 }
 
 /*
@@ -2038,8 +2078,10 @@ int ToStorage(EXPRESSIONS e, POSITION *length)
 		scrpos = e->onfile;
 		SeekFile(f->handle,&scrpos,SEEK_SET);
 		if ( ISNOTEQUALPOS(scrpos,e->onfile) ) {
-			MesPrint(":::Error in Scratch file");
+/* INTERNAL_ERROR_EXCL_START */
+			MesPrint("!>Error in Scratch file");
 			goto ErrReturn;
+/* INTERNAL_ERROR_EXCL_STOP */
 		}
 		f->POposition = e->onfile;
 		f->POfull = f->PObuffer;
@@ -2169,23 +2211,31 @@ int ToStorage(EXPRESSIONS e, POSITION *length)
 */
 	if ( WriteFile(AR.StoreData.Handle,(UBYTE *)(&(e->numdummies)),(LONG)sizeof(WORD)) != 
 		sizeof(WORD) ) {
-			MesPrint("Error while writing storage file");
+/* INTERNAL_ERROR_EXCL_START */
+			MesPrint("!>Error while writing storage file");
 			goto ErrReturn;
+/* INTERNAL_ERROR_EXCL_STOP */
 	}
 	if ( WriteFile(AR.StoreData.Handle,(UBYTE *)(&(e->numfactors)),(LONG)sizeof(WORD)) != 
 		sizeof(WORD) ) {
-			MesPrint("Error while writing storage file");
+/* INTERNAL_ERROR_EXCL_START */
+			MesPrint("!>Error while writing storage file");
 			goto ErrReturn;
+/* INTERNAL_ERROR_EXCL_STOP */
 	}
 	if ( WriteFile(AR.StoreData.Handle,(UBYTE *)(&(e->vflags)),(LONG)sizeof(WORD)) != 
 		sizeof(WORD) ) {
-			MesPrint("Error while writing storage file");
+/* INTERNAL_ERROR_EXCL_START */
+			MesPrint("!>Error while writing storage file");
 			goto ErrReturn;
+/* INTERNAL_ERROR_EXCL_STOP */
 	}
 	if ( WriteFile(AR.StoreData.Handle,(UBYTE *)(&(e->uflags)),(LONG)sizeof(WORD)) != 
 		sizeof(WORD) ) {
-			MesPrint("Error while writing storage file");
+/* INTERNAL_ERROR_EXCL_START */
+			MesPrint("!>Error while writing storage file");
 			goto ErrReturn;
+/* INTERNAL_ERROR_EXCL_STOP */
 	}
 	TELLFILE(AR.StoreData.Handle,&(indexent->position));
 	if ( f->handle >= 0 ) {
@@ -2197,12 +2247,16 @@ int ToStorage(EXPRESSIONS e, POSITION *length)
 			if ( ISLESSPOS(llength,scrpos) ) size = BASEPOSITION(llength);
 			else				             size = AO.wlen;
 			if ( ReadFile(f->handle,AO.wpos,size) != size ) {
-				MesPrint("Error while reading scratch file");
+/* INTERNAL_ERROR_EXCL_START */
+				MesPrint("!>Error while reading scratch file");
 				goto ErrReturn;
+/* INTERNAL_ERROR_EXCL_STOP */
 			}
 			if ( WriteFile(AR.StoreData.Handle,AO.wpos,size) != size ) {
-				MesPrint("Error while writing storage file");
+/* INTERNAL_ERROR_EXCL_START */
+				MesPrint("!>Error while writing storage file");
 				goto ErrReturn;
+/* INTERNAL_ERROR_EXCL_STOP */
 			}
 			ADDPOS(llength,-size);
 		}
@@ -2212,8 +2266,10 @@ int ToStorage(EXPRESSIONS e, POSITION *length)
 		ppp = (WORD *)((UBYTE *)(f->PObuffer) + BASEPOSITION(e->onfile));
 		if ( WriteFile(AR.StoreData.Handle,(UBYTE *)ppp,BASEPOSITION(*length)) != 
 		BASEPOSITION(*length) ) {
-			MesPrint("Error while writing storage file");
+/* INTERNAL_ERROR_EXCL_START */
+			MesPrint("!>Error while writing storage file");
 			goto ErrReturn;
+/* INTERNAL_ERROR_EXCL_STOP */
 		}
 	}
 	ADD2POS(*length,indexent->position);
@@ -2237,11 +2293,13 @@ int ToStorage(EXPRESSIONS e, POSITION *length)
 	if ( AO.wpos ) M_free(AO.wpos,"AO.wpos buffer");
 	AO.wpos = AO.wpoin = 0;
 	return(0);
+/* INTERNAL_ERROR_EXCL_START */
 ErrToSto:
-	MesPrint("---Error while storing namelists");
+	MesPrint("!>Error while storing namelists");
 	goto ErrReturn;
 ErrInSto:
-	MesPrint("Error in storage");
+	MesPrint("!>Error in storage");
+/* INTERNAL_ERROR_EXCL_STOP */
 ErrReturn:
 	if ( AO.wpos ) M_free(AO.wpos,"AO.wpos buffer");
 	AO.wpos = AO.wpoin = 0;
@@ -2302,8 +2360,10 @@ INDEXENTRY *NextFileIndex(POSITION *indexpos)
 	ADDPOS(AR.StoreData.Index.number,1);
 	return(ind);
 ErrNextS:
-	MesPrint("Error in storage file");
+/* INTERNAL_ERROR_EXCL_START */
+	MesPrint("!>Error in storage file");
 	return(0);
+/* INTERNAL_ERROR_EXCL_STOP */
 }
 
 /*
@@ -2329,13 +2389,21 @@ int SetFileIndex(void)
 #ifdef SYSDEPENDENTSAVE
 		SETBASEPOSITION(AR.StoreData.Fill,sizeof(FILEINDEX));
 #else
-		if ( WriteStoreHeader(AR.StoreData.Handle) ) return(MesPrint("Error writing storage file header"));
+		if ( WriteStoreHeader(AR.StoreData.Handle) ) {
+/* INTERNAL_ERROR_EXCL_START */
+			return(MesPrint("!>Error writing storage file header"));
+/* INTERNAL_ERROR_EXCL_STOP */
+		}
 		SETBASEPOSITION(AR.StoreData.Fill, (LONG)sizeof(FILEINDEX)+(LONG)sizeof(STOREHEADER));
 #endif
 		lo = (LONG *)(&AR.StoreData.Index);
 		for ( i = 0; i < j; i++ ) *lo++ = 0;
 		if ( WriteFile(AR.StoreData.Handle,(UBYTE *)(&AR.StoreData.Index),(LONG)(sizeof(FILEINDEX))) !=
-		(LONG)(sizeof(FILEINDEX)) ) return(MesPrint("Error writing storage file"));
+		(LONG)(sizeof(FILEINDEX)) ) {
+/* INTERNAL_ERROR_EXCL_START */
+			return(MesPrint("!>Error writing storage file"));
+/* INTERNAL_ERROR_EXCL_STOP */
+		}
 	}
 	else {
 		POSITION scrpos;
@@ -2346,7 +2414,11 @@ int SetFileIndex(void)
 #endif
 		SeekFile(AR.StoreData.Handle,&scrpos,SEEK_SET);
 		if ( ReadFile(AR.StoreData.Handle,(UBYTE *)(&AR.StoreData.Index),(LONG)(sizeof(FILEINDEX))) !=
-		(LONG)(sizeof(FILEINDEX)) ) return(MesPrint("Error reading storage file"));
+		(LONG)(sizeof(FILEINDEX)) ) {
+/* INTERNAL_ERROR_EXCL_START */
+			return(MesPrint("!>Error reading storage file"));
+/* INTERNAL_ERROR_EXCL_STOP */
+		}
 	}
 #ifdef SYSDEPENDENTSAVE
 	PUTZERO(AR.StoreData.Position);
@@ -2592,8 +2664,10 @@ WORD FindrNumber(WORD n, VARRENUM *v)
 	med = v->start;
 	if ( *hi == 0 ) {
 		if ( n != *hi ) {
-			MesPrint("Serious problems coming up in FindrNumber");
+/* INTERNAL_ERROR_EXCL_START */
+			MesPrint("!>Serious problems coming up in FindrNumber");
 			return(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 		}
 		return(*hi);
 	}
@@ -2615,9 +2689,10 @@ ErrFindr:
 	Reconstruction:
 */
 	{
+/* INTERNAL_ERROR_EXCL_START */
 		int i;
 		i = WORDDIF(v->hi,v->lo);
-		MesPrint("FindrNumber: n = %d, list has %d members",n,i);
+		MesPrint("!>FindrNumber: n = %d, list has %d members",n,i);
 		while ( i >= 0 ) {
 			MesPrint("v->lo[%d] = %d",i,v->lo[i]); i--;
 		}
@@ -2642,6 +2717,7 @@ ErrFindr:
 	return(WORDDIF(med,v->lo));
 ErrFindr2:
 	return(MesPrint("Renumbering problems"));
+/* INTERNAL_ERROR_EXCL_STOP */
 }
 
 /*
@@ -2690,16 +2766,6 @@ INDEXENTRY *FindInIndex(WORD expr, FILEDATA *f, WORD par, WORD mode)
 				if ( ( !par && ISEQUALPOS(indexpos,Expressions[expr].onfile) )
 				|| ( par && !StrCmp(EXPRNAME(expr),(UBYTE *)(ind->name)) ) ) {
 					nomatch = 1;
-/*
-MesPrint("index: position: %8p",&(ind->position));
-MesPrint("index: length: %8p",&(ind->length));
-MesPrint("index: variables: %8p",&(ind->variables));
-MesPrint("index: nsymbols: %d",ind->nsymbols);
-MesPrint("index: nindices: %d",ind->nindices);
-MesPrint("index: nvectors: %d",ind->nvectors);
-MesPrint("index: nfunctions: %d",ind->nfunctions);
-MesPrint("index: size: %d",ind->size);
-*/
 					if ( par ) return(ind);
 					scrpos = ind->position;
 					SeekFile(hand,&scrpos,SEEK_SET);
@@ -2782,8 +2848,10 @@ ErrGetTab:
 	}
 	return(0);
 ErrGt2:
-	MesPrint("Readerror in IndexSearch");
+/* INTERNAL_ERROR_EXCL_START */
+	MesPrint("!>Readerror in IndexSearch");
 	return(0);
+/* INTERNAL_ERROR_EXCL_STOP */
 }
 
 /*
@@ -3269,16 +3337,19 @@ GetTb3:
 	num *= sizeof(WORD);
 	if ( *AT.WorkPointer < 0 ||
 	ReadFile(AR.StoreData.Handle,(UBYTE *)(AT.WorkPointer+1),num) != num ) {
-		MesPrint("@Error in stored expressions file at position %10p",*position);
+/* INTERNAL_ERROR_EXCL_START */
+		MesPrint("!>Error in stored expressions file at position %10p",*position);
 		UNLOCK(AM.storefilelock);
 		AT.WorkPointer = oldwork;
 		return(0);
+/* INTERNAL_ERROR_EXCL_STOP */
 	}
 	UNLOCK(AM.storefilelock);
 	ADDPOS(*position,num+sizeof(WORD));
 	r->startposition = *position;
 	AT.WorkPointer = oldwork;
 	return(r);
+/* INTERNAL_ERROR_EXCL_START */
 GetTcall:
 	UNLOCK(AM.storefilelock);
 	AT.WorkPointer = oldwork;
@@ -3287,8 +3358,9 @@ GetTcall:
 ErrGt2:
 	UNLOCK(AM.storefilelock);
 	AT.WorkPointer = oldwork;
-	MesPrint("Readerror in GetTable");
+	MesPrint("!>Readerror in GetTable");
 	return(0);
+/* INTERNAL_ERROR_EXCL_STOP */
 }
 
 /*
@@ -3386,10 +3458,12 @@ int CopyExpression(FILEHANDLE *from, FILEHANDLE *to)
 	while ( ISLESSPOS(poscopy,posfrom) ) {
 		fullsize = ReadFile(from->handle,((UBYTE *)(from->PObuffer)),from->POsize);
 		if ( fullsize < 0 || ( fullsize % sizeof(WORD) ) != 0 ) {
+/* INTERNAL_ERROR_EXCL_START */
 			MLOCK(ErrorMessageLock);
-			MesPrint("Error while reading from disk while copying expression.");
+			MesPrint("!>Error while reading from disk while copying expression.");
 			MUNLOCK(ErrorMessageLock);
 			return(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 		}
 		fullsize /= sizeof(WORD);
 		from->POfull = from->PObuffer + fullsize;
@@ -3938,7 +4012,9 @@ static void ResizeCoeff32(UBYTE **bout, UBYTE *bend, UBYTE *top)
 		}
 
 		if ( out > (int32_t *)top ) {
-			MesPrint("Error in resizing coefficient!");
+/* INTERNAL_ERROR_EXCL_START */
+			MesPrint("!>Error in resizing coefficient!");
+/* INTERNAL_ERROR_EXCL_STOP */
 		}
 
 		*bout = (UBYTE *)out;
@@ -4031,8 +4107,11 @@ static unsigned int CompactifySizeof(unsigned int size)
 		case  4: return 1;
 		case  8: return 2;
 		case 16: return 3;
-		default: MesPrint("Error compactifying size.");
-		         return 3;
+		default:
+/* INTERNAL_ERROR_EXCL_START */
+			MesPrint("!>Error compactifying size.");
+		   return 3;
+/* INTERNAL_ERROR_EXCL_STOP */
 	}
 }
 
@@ -4082,8 +4161,11 @@ int ReadSaveHeader(void)
 	AO.bufferedInd = 0;
 
 	if ( ReadFile(AO.SaveData.Handle,(UBYTE *)(&AO.SaveHeader),
-		(LONG)sizeof(STOREHEADER)) != (LONG)sizeof(STOREHEADER) )
-		return(MesPrint("Error reading save file header"));
+		(LONG)sizeof(STOREHEADER)) != (LONG)sizeof(STOREHEADER) ) {
+/* INTERNAL_ERROR_EXCL_START */
+			return(MesPrint("!>Error reading save file header"));
+/* INTERNAL_ERROR_EXCL_STOP */
+		}
 
 	/* check whether save-file has no header. if yes then it is an old version
 	   of FORM -> go back to position 0 in file which then contains the first
@@ -4199,7 +4281,9 @@ LONG ReadSaveIndex(FILEINDEX *fileind)
 
 		if ( ReadFile(AO.SaveData.Handle, (UBYTE *)fileind, sizeof(FILEINDEX))
 				!= sizeof(FILEINDEX) ) {
-			return ( MesPrint("Error(1) reading stored expression.") );
+/* INTERNAL_ERROR_EXCL_START */
+			return ( MesPrint("!>Error(1) reading stored expression.") );
+/* INTERNAL_ERROR_EXCL_STOP */
 		}
 
 		/* do we need to flip the endianness? */
@@ -4412,7 +4496,9 @@ LONG ReadSaveVariables(UBYTE *buffer, UBYTE *top, LONG *size, LONG *outsize,\
 		}
 
 		if ( ( numread = ReadFile(AO.SaveData.Handle, in, *size) ) != *size ) {
-			return ( MesPrint("Error(2) reading stored expression.") );
+/* INTERNAL_ERROR_EXCL_START */
+			return ( MesPrint("!>Error(2) reading stored expression.") );
+/* INTERNAL_ERROR_EXCL_STOP */
 		}
 
 		*size = 0;
@@ -5027,8 +5113,10 @@ ReadSaveTerm32(UBYTE *bin, UBYTE *binend, UBYTE **bout, UBYTE *boutend, UBYTE *t
 								++out; ++r;
 								break;
 							} else {
-								MesPrint("short function code %d not implemented.", *out);
+/* INTERNAL_ERROR_EXCL_START */
+								MesPrint("!>short function code %d not implemented.", *out);
 								return ( (UBYTE *)in );
+/* INTERNAL_ERROR_EXCL_STOP */
 							}
 					}
 				}
@@ -5082,8 +5170,10 @@ ReadSaveTerm32(UBYTE *bin, UBYTE *binend, UBYTE **bout, UBYTE *boutend, UBYTE *t
 			}
 		}
 		else {
-			MesPrint("ID %d not recognized.", id);
+/* INTERNAL_ERROR_EXCL_START */
+			MesPrint("!>ID %d not recognized.", id);
 			return ( (UBYTE *)in );
+/* INTERNAL_ERROR_EXCL_STOP */
 		}
 
 		*newsubtermp = out - newsubtermp + 1;
@@ -5172,7 +5262,9 @@ LONG ReadSaveExpression(UBYTE *buffer, UBYTE *top, LONG *size, LONG *outsize)
 		outend = out + *size;
 
 		if ( ReadFile(AO.SaveData.Handle, in, *size) != *size ) {
-			return ( MesPrint("Error(3) reading stored expression.") );
+/* INTERNAL_ERROR_EXCL_START */
+			return ( MesPrint("!>Error(3) reading stored expression.") );
+/* INTERNAL_ERROR_EXCL_STOP */
 		}
 
 		if ( AO.transFlag & 1 ) {

--- a/sources/tables.c
+++ b/sources/tables.c
@@ -171,9 +171,11 @@ int InsTableTree(TABLES T, WORD *tp)
 			}
 		}
 	}
-	MesPrint("Serious problems in InsTableTree!\n");
+/* INTERNAL_ERROR_EXCL_START */
+	MesPrint("!>Serious problems in InsTableTree!\n");
 	Terminate(-1);
 	return(0);
+/* INTERNAL_ERROR_EXCL_STOP */
 balance:;
 	for (;;) {
 		p = boomlijst + ip;
@@ -321,9 +323,11 @@ int FindTableTree(TABLES T, WORD *tp, int inc)
 			else return(-1);
 		}
 	}
-	MesPrint("Serious problems in FindTableTree\n");
+/* INTERNAL_ERROR_EXCL_START */
+	MesPrint("!>Serious problems in FindTableTree\n");
 	Terminate(-1);
 	return(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 }
 
 /*
@@ -357,8 +361,10 @@ int DoTableExpansion(WORD *term, WORD level)
 		t += t[1];
 	}
 	if ( t >= stopper ) {
-		MesPrint("Internal error: Missing table_ function");
+/* INTERNAL_ERROR_EXCL_START */
+		MesPrint("!>Internal error: Missing table_ function");
 		Terminate(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 	}
 /*
 	Table in T. Now collect the numbers of the symbols;
@@ -1459,8 +1465,10 @@ int TestUse(WORD *term, WORD level)
 			}
 		}
 		else {
-			MesPrint("TestUse: Encountered a table element inside tbl_ that does not correspond to a tablebase element");
+/* INTERNAL_ERROR_EXCL_START */
+			MesPrint("!>TestUse: Encountered a table element inside tbl_ that does not correspond to a tablebase element");
 			error = -1;
+/* INTERNAL_ERROR_EXCL_STOP */
 		}
 	}
 	return(error);
@@ -1715,8 +1723,10 @@ int CoTBuse(UBYTE *s)
 			MesPrint("&%s should be a sparse table",tablename);
 		}
 	if ( T->spare && T->mode == 0 ) {
-		MesPrint("In table %s we have a problem with stubb orders in CoTBuse",tablename);
+/* INTERNAL_ERROR_EXCL_START */
+		MesPrint("!>In table %s we have a problem with stubb orders in CoTBuse",tablename);
 		error = -1;
+/* INTERNAL_ERROR_EXCL_STOP */
 	}
 /*		if ( T->spare == 0 ) { SpareTable(T); } */
 		for ( i = 0; i < d->info.numberofindexblocks; i++ ) {
@@ -1733,10 +1743,12 @@ int CoTBuse(UBYTE *s)
 					}
 					sum = FindTableTree(T,AT.WorkPointer,1);
 					if ( sum < 0 ) {
-						MesPrint("Table %s in tablebase %s has not been loaded properly"
+/* INTERNAL_ERROR_EXCL_START */
+						MesPrint("!>Table %s in tablebase %s has not been loaded properly"
 								,tablename,tablebasename);
 						error = 1;
 						continue;
+/* INTERNAL_ERROR_EXCL_STOP */
 					}
 					sum += ABS(T->numind) + 4;
 					mode = T->tablepointers[sum];

--- a/sources/threads.c
+++ b/sources/threads.c
@@ -358,10 +358,12 @@ int StartAllThreads(int number)
 MesPrint("AB = %x %x %x  %d",AB[0],AB[1],AB[2], identityofthreads);
 */
 	return(0);
+/* INTERNAL_ERROR_EXCL_START */
 failure:
-	MesPrint("Cannot start %d threads",number);
+	MesPrint("!>Cannot start %d threads",number);
 	Terminate(-1);
 	return(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 }
 
 /*
@@ -798,12 +800,14 @@ ALLPRIVATES *InitializeOneThread(int identity)
 
 	ReserveTempFiles(2);
 	return(B);
+/* INTERNAL_ERROR_EXCL_START */
 OnError:;
 	MLOCK(ErrorMessageLock);
-	MesPrint("Error initializing thread %d",identity);
+	MesPrint("!>Error initializing thread %d",identity);
 	MUNLOCK(ErrorMessageLock);
 	Terminate(-1);
 	return(B);
+/* INTERNAL_ERROR_EXCL_STOP */
 }
 
 /*
@@ -1320,10 +1324,12 @@ void *RunThread(void *dummy)
 				Start with getting some buffers synchronized with the compiler
 */
 				if ( UpdateOneThread(identity) ) {
+/* INTERNAL_ERROR_EXCL_START */
 					MLOCK(ErrorMessageLock);
-					MesPrint("Update error in starting expression in thread %d in module %d",identity,AC.CModule);
+					MesPrint("!>Update error in starting expression in thread %d in module %d",identity,AC.CModule);
 					MUNLOCK(ErrorMessageLock);
 					Terminate(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 				}
 				AR.DeferFlag = AC.ComDefer;
 				AR.sLevel = AS.sLevel;
@@ -1434,11 +1440,13 @@ void *RunThread(void *dummy)
 						PolyFunClean(BHEAD term);
 				  }
 				  if ( Generator(BHEAD term,0) ) {
+/* INTERNAL_ERROR_EXCL_START */
 					LowerSortLevel();
 					MLOCK(ErrorMessageLock);
-					MesPrint("Error in processing one term in thread %d in module %d",identity,AC.CModule);
+					MesPrint("!>Error in processing one term in thread %d in module %d",identity,AC.CModule);
 					MUNLOCK(ErrorMessageLock);
 					Terminate(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 				  }
 				  AN.ninterms++;
 				  }
@@ -1925,11 +1933,13 @@ bucketstolen:;
 			#] OPTIMIZEEXPRESSION : 
 */
 			default:
+/* INTERNAL_ERROR_EXCL_START */
 				MLOCK(ErrorMessageLock);
-				MesPrint("Illegal wakeup signal %d for thread %d",wakeupsignal,identity);
+				MesPrint("!>Illegal wakeup signal %d for thread %d",wakeupsignal,identity);
 				MUNLOCK(ErrorMessageLock);
 				Terminate(-1);
 				break;
+/* INTERNAL_ERROR_EXCL_STOP */
 		}
 		/* we need the following update in case we are using checkpoints. then we
 		   need to readjust the clocks when recovering using this information */
@@ -2039,11 +2049,13 @@ void *RunSortBot(void *dummy)
 			#] CLEARCLOCK : 
 */
 			default:
+/* INTERNAL_ERROR_EXCL_START */
 				MLOCK(ErrorMessageLock);
-				MesPrint("Illegal wakeup signal %d for thread %d",wakeupsignal,identity);
+				MesPrint("!>Illegal wakeup signal %d for thread %d",wakeupsignal,identity);
 				MUNLOCK(ErrorMessageLock);
 				Terminate(-1);
 				break;
+/* INTERNAL_ERROR_EXCL_STOP */
 		}
 	}
 EndOfThread:;
@@ -2427,10 +2439,12 @@ void MasterWaitAllBlocks(void)
 void WakeupThread(int identity, int signalnumber)
 {
 	if ( signalnumber == 0 ) {
+/* INTERNAL_ERROR_EXCL_START */
 		MLOCK(ErrorMessageLock);
-		MesPrint("Illegal wakeup signal for thread %d",identity);
+		MesPrint("!>Illegal wakeup signal for thread %d",identity);
 		MUNLOCK(ErrorMessageLock);
 		Terminate(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 	}
 	LOCK(wakeuplocks[identity]);
 	wakeup[identity] = signalnumber;
@@ -2453,10 +2467,12 @@ void WakeupThread(int identity, int signalnumber)
 void WakeupMasterFromThread(int identity, int signalnumber)
 {
 	if ( signalnumber == 0 ) {
+/* INTERNAL_ERROR_EXCL_START */
 		MLOCK(ErrorMessageLock);
-		MesPrint("Illegal wakeup signal for master %d",identity);
+		MesPrint("!>Illegal wakeup signal for master %d",identity);
 		MUNLOCK(ErrorMessageLock);
 		Terminate(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 	}
 	LOCK(wakeupmasterthreadlocks[identity]);
 	wakeupmasterthread[identity] = signalnumber;
@@ -3615,10 +3631,12 @@ int PutToMaster(PHEAD WORD *term)
 			// In this case, there has been an accounting error in a previous use
 			// of this block. Blocks that have been read from and unlocked, should
 			// have BlockTerms == 0.
+/* INTERNAL_ERROR_EXCL_START */
 			MLOCK(ErrorMessageLock);
-			MesPrint("Error in PutToMaster, starting a block with BlockTerms != 0");
+			MesPrint("!>Error in PutToMaster, starting a block with BlockTerms != 0");
 			MUNLOCK(ErrorMessageLock);
 			Terminate(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 		}
 	}
 
@@ -3658,10 +3676,12 @@ SortBotOut(PHEAD WORD *term)
 	else {
 		numberofterms++;
 		if ( ( im = PutOut(BHEAD term,&SortBotPosition,AR.outfile,1) ) < 0 ) {
+/* INTERNAL_ERROR_EXCL_START */
 			MLOCK(ErrorMessageLock);
-			MesPrint("Called from MasterMerge/SortBotOut");
+			MesPrint("!>Called from MasterMerge/SortBotOut");
 			MUNLOCK(ErrorMessageLock);
 			return(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 		}
 		ADDPOS(AT.SS->SizeInFile[0],im);
 		return(im);
@@ -4096,10 +4116,12 @@ NextTerm:
 */
 	S->TermsLeft++;
 	if ( ( im = PutOut(B0,poin[k],&position,fout,1) ) < 0 ) {
+/* INTERNAL_ERROR_EXCL_START */
 		MLOCK(ErrorMessageLock);
-		MesPrint("Called from MasterMerge with k = %d (stream %d)",k,S->ktoi[k]);
+		MesPrint("!>Called from MasterMerge with k = %d (stream %d)",k,S->ktoi[k]);
 		MUNLOCK(ErrorMessageLock);
 		goto ReturnError;
+/* INTERNAL_ERROR_EXCL_STOP */
 	}
 	ADDPOS(S->SizeInFile[0],im);
 	goto NextTerm;
@@ -4250,11 +4272,13 @@ int SortBotMasterMerge(void)
 		WakeupThread(i,RUNSORTBOT);
 	}
 	if ( SortBotMerge(BHEAD0) ) {
+/* INTERNAL_ERROR_EXCL_START */
 		MLOCK(ErrorMessageLock);
-		MesPrint("Called from SortBotMasterMerge");
+		MesPrint("!>Called from SortBotMasterMerge");
 		MUNLOCK(ErrorMessageLock);
 		AS.MasterSort = 0;
 		return(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 	}
 /*
 	And next the cleanup
@@ -4371,11 +4395,13 @@ int SortBotMerge(PHEAD0)
 */
 			Bin1->T.SB.BlockTerms[blin1]--;
 			if ( SortBotOut(BHEAD term1) < 0 ) {
+/* INTERNAL_ERROR_EXCL_START */
 				MLOCK(ErrorMessageLock);
-				MesPrint("Called from SortBotMerge with thread = %d",AT.identity);
+				MesPrint("!>Called from SortBotMerge with thread = %d",AT.identity);
 				MUNLOCK(ErrorMessageLock);
 				error = -1;
 				goto ReturnError;
+/* INTERNAL_ERROR_EXCL_STOP */
 			}
 			term1 += *term1;
 			if ( Bin1->T.SB.BlockTerms[blin1] == 0 ) {
@@ -4405,11 +4431,13 @@ int SortBotMerge(PHEAD0)
 */
 			Bin2->T.SB.BlockTerms[blin2]--;
 			if ( SortBotOut(BHEAD term2) < 0 ) {
+/* INTERNAL_ERROR_EXCL_START */
 				MLOCK(ErrorMessageLock);
-				MesPrint("Called from SortBotMerge with thread = %d",AT.identity);
+				MesPrint("!>Called from SortBotMerge with thread = %d",AT.identity);
 				MUNLOCK(ErrorMessageLock);
 				error = -1;
 				goto ReturnError;
+/* INTERNAL_ERROR_EXCL_STOP */
 			}
 next2:
 			term2 += *term2;
@@ -4557,11 +4585,13 @@ next2:
 					UnpackFloat(aux2,fun2);
 				}
 				else {
+/* INTERNAL_ERROR_EXCL_START */
 					MLOCK(ErrorMessageLock);
-					MesPrint("Illegal value %d for AT.SortFloatMode in SortBotMerge.",AT.SortFloatMode);
+					MesPrint("!>Illegal value %d for AT.SortFloatMode in SortBotMerge.",AT.SortFloatMode);
 					MUNLOCK(ErrorMessageLock);
 					Terminate(-1);
 					return(0);
+/* INTERNAL_ERROR_EXCL_STOP */
 				}
 				mpf_add(aux3,aux1,aux2);
 				size3 = mpf_sgn(aux3);
@@ -4646,21 +4676,25 @@ next2:
 					wp[0] = to - wp;
 PutOutwp:
 					if ( SortBotOut(BHEAD wp) < 0 ) {
+/* INTERNAL_ERROR_EXCL_START */
 						MLOCK(ErrorMessageLock);
-						MesPrint("Called from SortBotMerge with thread = %d",AT.identity);
+						MesPrint("!>Called from SortBotMerge with thread = %d",AT.identity);
 						MUNLOCK(ErrorMessageLock);
 						error = -1;
 						goto ReturnError;
+/* INTERNAL_ERROR_EXCL_STOP */
 					}
 					goto cancelled;
 				}
 			}
 			if ( SortBotOut(BHEAD term1) < 0 ) {
+/* INTERNAL_ERROR_EXCL_START */
 				MLOCK(ErrorMessageLock);
-				MesPrint("Called from SortBotMerge with thread = %d",AT.identity);
+				MesPrint("!>Called from SortBotMerge with thread = %d",AT.identity);
 				MUNLOCK(ErrorMessageLock);
 				error = -1;
 				goto ReturnError;
+/* INTERNAL_ERROR_EXCL_STOP */
 			}
 cancelled:;		/* Now we need two new terms */
 			term1 += *term1;
@@ -4698,11 +4732,13 @@ cancelled:;		/* Now we need two new terms */
 		while ( *term1 ) {
 			Bin1->T.SB.BlockTerms[blin1]--;
 			if ( SortBotOut(BHEAD term1) < 0 ) {
+/* INTERNAL_ERROR_EXCL_START */
 				MLOCK(ErrorMessageLock);
-				MesPrint("Called from SortBotMerge with thread = %d",AT.identity);
+				MesPrint("!>Called from SortBotMerge with thread = %d",AT.identity);
 				MUNLOCK(ErrorMessageLock);
 				error = -1;
 				goto ReturnError;
+/* INTERNAL_ERROR_EXCL_STOP */
 			}
 			if ( Bin1->T.SB.BlockTerms[blin1] == 0 ) {
 
@@ -4737,11 +4773,13 @@ cancelled:;		/* Now we need two new terms */
 		while ( *term2 ) {
 			Bin2->T.SB.BlockTerms[blin2]--;
 			if ( SortBotOut(BHEAD term2) < 0 ) {
+/* INTERNAL_ERROR_EXCL_START */
 				MLOCK(ErrorMessageLock);
-				MesPrint("Called from SortBotMerge with thread = %d",AT.identity);
+				MesPrint("!>Called from SortBotMerge with thread = %d",AT.identity);
 				MUNLOCK(ErrorMessageLock);
 				error = -1;
 				goto ReturnError;
+/* INTERNAL_ERROR_EXCL_STOP */
 			}
 			if ( Bin2->T.SB.BlockTerms[blin2] == 0 ) {
 
@@ -4853,8 +4891,10 @@ int IniSortBlocks(int numworkers)
 /*
 		This should have been taken care of in RecalcSetups.
 */
-		MesPrint("We have a problem with the size of the blocks in IniSortBlocks");
+/* INTERNAL_ERROR_EXCL_START */
+		MesPrint("!>We have a problem with the size of the blocks in IniSortBlocks");
 		Terminate(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 	}
 /*
 	Layout:  For each worker
@@ -4888,8 +4928,10 @@ int IniSortBlocks(int numworkers)
 		}
 	}
 	if ( w > S->sTop2 ) {
-		MesPrint("Counting problem in IniSortBlocks");
+/* INTERNAL_ERROR_EXCL_START */
+		MesPrint("!>Counting problem in IniSortBlocks");
 		Terminate(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 	}
 	return(0);
 }
@@ -4935,8 +4977,10 @@ int UpdateSortBlocks(int numworkers)
 /*
 		This should have been taken care of in RecalcSetups.
 */
-		MesPrint("We have a problem with the size of the blocks in UpdateSortBlocks");
+/* INTERNAL_ERROR_EXCL_START */
+		MesPrint("!>We have a problem with the size of the blocks in UpdateSortBlocks");
 		Terminate(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 	}
 /*
 	Layout:  For each worker
@@ -4957,8 +5001,10 @@ int UpdateSortBlocks(int numworkers)
 		}
 	}
 	if ( w > S->sTop2 ) {
-		MesPrint("Counting problem in UpdateSortBlocks");
+/* INTERNAL_ERROR_EXCL_START */
+		MesPrint("!>Counting problem in UpdateSortBlocks");
 		Terminate(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 	}
 	return(0);
 }

--- a/sources/token.c
+++ b/sources/token.c
@@ -1978,8 +1978,10 @@ int simp4token(SBYTE *s)
 			case CNUMBER: type = TNUMBER1; break;
 			case CDUBIOUS: type = TDUBIOUS; break;
 			default:
-				MesPrint("&Unknown set type in simp4token");
+/* INTERNAL_ERROR_EXCL_START */
+				MesPrint("!>Unknown set type in simp4token");
 				error = 1; type = CDUBIOUS; break;
+/* INTERNAL_ERROR_EXCL_STOP */
 		}
 		s3 = s1buf; s1++;
 		while ( *s1 >= 0 ) *s3++ = *s1++;
@@ -2101,9 +2103,11 @@ int simp6token(SBYTE *tokens, int mode)
 */
 					if ( ( renumber = GetTable(n,&position,0) ) == 0 )
 					{
+/* INTERNAL_ERROR_EXCL_START */
 						error = 1;
-						MesPrint("&Problems getting information about stored expression %s(4)"
+						MesPrint("!>Problems getting information about stored expression %s(4)"
 						,EXPRNAME(n));
+/* INTERNAL_ERROR_EXCL_STOP */
 					}
 /*
 #ifdef WITHPTHREADS

--- a/sources/tools.c
+++ b/sources/tools.c
@@ -2250,7 +2250,9 @@ void *Malloc1(LONG size, const char *messageifwrong)
 	int i;
 	LOCK(MallocLock);
 	if ( size == 0 ) {
-		MesPrint("%wAsking for 0 bytes in Malloc1");
+/* INTERNAL_ERROR_EXCL_START */
+		MesPrint("!>%wAsking for 0 bytes in Malloc1");
+/* INTERNAL_ERROR_EXCL_STOP */
 	}
 #endif
 #ifdef WITHSTATS
@@ -2781,17 +2783,21 @@ void *FromVarList(LIST *L)
 			if ( L == &(AP.DollarList) ) {
 				if ( L->maxnum > MAXDOLLARVARIABLES ) L->maxnum = MAXDOLLARVARIABLES;
 				if ( L->num >= MAXDOLLARVARIABLES ) {
-					MesPrint("!!!More than %l objects in list of $-variables",
+/* INTERNAL_ERROR_EXCL_START */
+					MesPrint("!>More than %l objects in list of $-variables",
 						MAXDOLLARVARIABLES);
 					Terminate(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 				}
 			}
 			else {
 				if ( L->maxnum > MAXVARIABLES ) L->maxnum = MAXVARIABLES;
 				if ( L->num >= MAXVARIABLES ) {
-					MesPrint("!!!More than %l objects in list of variables",
+/* INTERNAL_ERROR_EXCL_START */
+					MesPrint("!>More than %l objects in list of variables",
 						MAXVARIABLES);
 					Terminate(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 				}
 			}
 		}
@@ -3130,10 +3136,12 @@ WORD ToPolyFunGeneral(PHEAD WORD *term)
 							tt += 2;
 						}
 						else {
+/* INTERNAL_ERROR_EXCL_START */
 							MLOCK(ErrorMessageLock);
-							MesPrint("Internal error: Zero in PolyRatFun");
+							MesPrint("!>Internal error: Zero in PolyRatFun");
 							MUNLOCK(ErrorMessageLock);
 							Terminate(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 						}
 					}
 				}
@@ -3387,8 +3395,10 @@ docompare:
 	return(0);
  
 argerror:
-	MesPrint("Illegal type of short function argument in Normalize");
+/* INTERNAL_ERROR_EXCL_START */
+	MesPrint("!>Illegal type of short function argument in Normalize");
 	Terminate(-1); return(0);
+/* INTERNAL_ERROR_EXCL_STOP */
 }
 
 /*
@@ -3570,7 +3580,9 @@ LONG Timer(int par)
 	struct timespec t;
 	if ( par == 0 ) {
 		if ( clock_gettime(CLOCK_THREAD_CPUTIME_ID, &t) ) {
-			MesPrint("Error in getting timing information");
+/* INTERNAL_ERROR_EXCL_START */
+			MesPrint("!>Error in getting timing information");
+/* INTERNAL_ERROR_EXCL_STOP */
 		}
 		return (LONG)t.tv_sec * 1000 + (LONG)t.tv_nsec / 1000000;
 	}
@@ -3804,18 +3816,22 @@ int TestTerm(WORD *term)
 	endterm = term + *term;
 	coeffsize = ABS(endterm[-1]);
 	if ( coeffsize >= *term ) {
+/* INTERNAL_ERROR_EXCL_START */
 		MLOCK(ErrorMessageLock);
-		MesPrint("TestTerm: Internal inconsistency in term. Coefficient too big.");
+		MesPrint("!>TestTerm: Internal inconsistency in term. Coefficient too big.");
 		MUNLOCK(ErrorMessageLock);
 		errorcode = 1;
 		goto finish;
+/* INTERNAL_ERROR_EXCL_STOP */
 	}
 	if ( ( coeffsize < 3 ) || ( ( coeffsize & 1 ) != 1 ) ) {
+/* INTERNAL_ERROR_EXCL_START */
 		MLOCK(ErrorMessageLock);
-		MesPrint("TestTerm: Internal inconsistency in term. Wrong size coefficient.");
+		MesPrint("!>TestTerm: Internal inconsistency in term. Wrong size coefficient.");
 		MUNLOCK(ErrorMessageLock);
 		errorcode = 2;
 		goto finish;
+/* INTERNAL_ERROR_EXCL_STOP */
 	}
 	t = term+1;
 	tstop = endterm - coeffsize;
@@ -3830,12 +3846,14 @@ int TestTerm(WORD *term)
 				break;
 			case SNUMBER:
 			case LNUMBER:
+/* INTERNAL_ERROR_EXCL_START */
 				MLOCK(ErrorMessageLock);
-				MesPrint("TestTerm: Internal inconsistency in term. L or S number");
+				MesPrint("!>TestTerm: Internal inconsistency in term. L or S number");
 				MUNLOCK(ErrorMessageLock);
 				errorcode = 3;
 				goto finish;
 				break;
+/* INTERNAL_ERROR_EXCL_STOP */
 			case EXPRESSION:
 			case SUBEXPRESSION:
 			case DOLLAREXPRESSION:
@@ -3851,48 +3869,58 @@ int TestTerm(WORD *term)
 			case MINVECTOR:
 			case SETEXP:
 			case ARGFIELD:
+/* INTERNAL_ERROR_EXCL_START */
 				MLOCK(ErrorMessageLock);
-				MesPrint("TestTerm: Internal inconsistency in term. Illegal subterm.");
+				MesPrint("!>TestTerm: Internal inconsistency in term. Illegal subterm.");
 				MUNLOCK(ErrorMessageLock);
 				errorcode = 5;
 				goto finish;
 				break;
+/* INTERNAL_ERROR_EXCL_STOP */
 			case ARGWILD:
 				break;
 			default:
 				if ( *t <= 0 ) {
+/* INTERNAL_ERROR_EXCL_START */
 					MLOCK(ErrorMessageLock);
-					MesPrint("TestTerm: Internal inconsistency in term. Illegal subterm number.");
+					MesPrint("!>TestTerm: Internal inconsistency in term. Illegal subterm number.");
 					MUNLOCK(ErrorMessageLock);
 					errorcode = 6;
 					goto finish;
+/* INTERNAL_ERROR_EXCL_STOP */
 				}
 /*
 				This is a regular function.
 */
 				if ( *t-FUNCTION >= NumFunctions ) {
+/* INTERNAL_ERROR_EXCL_START */
 					MLOCK(ErrorMessageLock);
-					MesPrint("TestTerm: Internal inconsistency in term. Illegal function number");
+					MesPrint("!>TestTerm: Internal inconsistency in term. Illegal function number");
 					MUNLOCK(ErrorMessageLock);
 					errorcode = 7;
 					goto finish;
+/* INTERNAL_ERROR_EXCL_STOP */
 				}
 				funstop = t + t[1];
 				if ( funstop > tstop ) goto subtermsize;
 				if ( t[2] != 0 ) {
+/* INTERNAL_ERROR_EXCL_START */
 					MLOCK(ErrorMessageLock);
-					MesPrint("TestTerm: Internal inconsistency in term. Dirty flag nonzero.");
+					MesPrint("!>TestTerm: Internal inconsistency in term. Dirty flag nonzero.");
 					MUNLOCK(ErrorMessageLock);
 					errorcode = 8;
 					goto finish;
+/* INTERNAL_ERROR_EXCL_STOP */
 				}
 				targ = t + FUNHEAD;
 				if ( targ > funstop ) {
+/* INTERNAL_ERROR_EXCL_START */
 					MLOCK(ErrorMessageLock);
-					MesPrint("TestTerm: Internal inconsistency in term. Illegal function size.");
+					MesPrint("!>TestTerm: Internal inconsistency in term. Illegal function size.");
 					MUNLOCK(ErrorMessageLock);
 					errorcode = 9;
 					goto finish;
+/* INTERNAL_ERROR_EXCL_STOP */
 				}
 				if ( functions[*t-FUNCTION].spec >= TENSORFUNCTION ) {
 				}
@@ -3900,11 +3928,13 @@ int TestTerm(WORD *term)
 				  while ( targ < funstop ) {
 					if ( *targ < 0 ) {
 						if ( *targ <= -(FUNCTION+NumFunctions) ) {
+/* INTERNAL_ERROR_EXCL_START */
 							MLOCK(ErrorMessageLock);
-							MesPrint("TestTerm: Internal inconsistency in term. Illegal function number in argument.");
+							MesPrint("!>TestTerm: Internal inconsistency in term. Illegal function number in argument.");
 							MUNLOCK(ErrorMessageLock);
 							errorcode = 10;
 							goto finish;
+/* INTERNAL_ERROR_EXCL_STOP */
 						}
 						if ( *targ <= -FUNCTION ) { targ++; }
 						else {
@@ -3913,46 +3943,56 @@ int TestTerm(WORD *term)
 							&& ( *targ != -SNUMBER )
 							&& ( *targ != -ARGWILD )
 							&& ( *targ != -INDEX ) ) {
+/* INTERNAL_ERROR_EXCL_START */
 								MLOCK(ErrorMessageLock);
-								MesPrint("TestTerm: Internal inconsistency in term. Illegal object in argument.");
+								MesPrint("!>TestTerm: Internal inconsistency in term. Illegal object in argument.");
 								MUNLOCK(ErrorMessageLock);
 								errorcode = 11;
 								goto finish;
+/* INTERNAL_ERROR_EXCL_STOP */
 							}
 							targ += 2;
 						}
 					}
 					else if ( ( *targ < ARGHEAD ) || ( targ+*targ > funstop ) ) {
+/* INTERNAL_ERROR_EXCL_START */
 						MLOCK(ErrorMessageLock);
-						MesPrint("TestTerm: Internal inconsistency in term. Illegal size of argument.");
+						MesPrint("!>TestTerm: Internal inconsistency in term. Illegal size of argument.");
 						MUNLOCK(ErrorMessageLock);
 						errorcode = 12;
 						goto finish;
+/* INTERNAL_ERROR_EXCL_STOP */
 					}
 					else if ( targ[1] != 0 ) {
+/* INTERNAL_ERROR_EXCL_START */
 						MLOCK(ErrorMessageLock);
-						MesPrint("TestTerm: Internal inconsistency in term. Dirty flag in argument.");
+						MesPrint("!>TestTerm: Internal inconsistency in term. Dirty flag in argument.");
 						MUNLOCK(ErrorMessageLock);
 						errorcode = 13;
 						goto finish;
+/* INTERNAL_ERROR_EXCL_STOP */
 					}
 					else {
 						targstop = targ + *targ;
 						argterm = targ + ARGHEAD;
 						while ( argterm < targstop ) {
 							if ( ( *argterm < 4 ) || ( argterm + *argterm > targstop ) ) {
+/* INTERNAL_ERROR_EXCL_START */
 								MLOCK(ErrorMessageLock);
-								MesPrint("TestTerm: Internal inconsistency in term. Illegal termsize in argument.");
+								MesPrint("!>TestTerm: Internal inconsistency in term. Illegal termsize in argument.");
 								MUNLOCK(ErrorMessageLock);
 								errorcode = 14;
 								goto finish;
+/* INTERNAL_ERROR_EXCL_STOP */
 							}
 							if ( TestTerm(argterm) != 0 ) {
+/* INTERNAL_ERROR_EXCL_START */
 								MLOCK(ErrorMessageLock);
-								MesPrint("TestTerm: Internal inconsistency in term. Called from TestTerm.");
+								MesPrint("!>TestTerm: Internal inconsistency in term. Called from TestTerm.");
 								MUNLOCK(ErrorMessageLock);
 								errorcode = 15;
 								goto finish;
+/* INTERNAL_ERROR_EXCL_STOP */
 							}
 							argterm += *argterm;
 						}
@@ -3965,11 +4005,13 @@ int TestTerm(WORD *term)
 		tt = t + t[1];
 		if ( tt > tstop ) {
 subtermsize:
+/* INTERNAL_ERROR_EXCL_START */
 			MLOCK(ErrorMessageLock);
-			MesPrint("TestTerm: Internal inconsistency in term. Illegal subterm size.");
+			MesPrint("!>TestTerm: Internal inconsistency in term. Illegal subterm size.");
 			MUNLOCK(ErrorMessageLock);
 			errorcode = 100;
 			goto finish;
+/* INTERNAL_ERROR_EXCL_STOP */
 		}
 		t = tt;
 	}

--- a/sources/transform.c
+++ b/sources/transform.c
@@ -947,10 +947,12 @@ abortlyndon:;
 						}
 						break;
 					default:
+/* INTERNAL_ERROR_EXCL_START */
 						MLOCK(ErrorMessageLock);
-						MesPrint("Irregular code in execution of transform statement");
+						MesPrint("!>Irregular code in execution of transform statement");
 						MUNLOCK(ErrorMessageLock);
 						Terminate(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 				}
 				onetransform += *onetransform;
 			} while ( *onetransform );
@@ -1172,10 +1174,12 @@ int RunEncode(PHEAD WORD *fun, WORD *args, WORD *info)
 		NumberFree(scrat1,"RunEncode");
 	}
 	else {
+/* INTERNAL_ERROR_EXCL_START */
 		MLOCK(ErrorMessageLock);
-		MesPrint("Unimplemented type of encoding encountered in RunEncode");
+		MesPrint("!>Unimplemented type of encoding encountered in RunEncode");
 		MUNLOCK(ErrorMessageLock);
 		Terminate(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 	}
 	return(0);
 CalledFrom:
@@ -1335,10 +1339,12 @@ int RunDecode(PHEAD WORD *fun, WORD *args, WORD *info)
 		NumberFree(scrat1,"RunEncode");
 	}
 	else {
+/* INTERNAL_ERROR_EXCL_START */
 		MLOCK(ErrorMessageLock);
-		MesPrint("Unimplemented type of encoding encountered in RunDecode");
+		MesPrint("!>Unimplemented type of encoding encountered in RunDecode");
 		MUNLOCK(ErrorMessageLock);
 		Terminate(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 	}
 	return(0);
 CalledFrom:
@@ -1472,10 +1478,12 @@ int RunReplace(PHEAD WORD *fun, WORD *args, WORD *info)
 			}
 		}
 		else {
+/* INTERNAL_ERROR_EXCL_START */
 			MLOCK(ErrorMessageLock);
-			MesPrint("&irregular code found in replace transformation (RunReplace)");
+			MesPrint("!>irregular code found in replace transformation (RunReplace)");
 			MUNLOCK(ErrorMessageLock);
 			Terminate(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 		}
 	}
 	AT.WorkPointer = term2;

--- a/sources/wildcard.c
+++ b/sources/wildcard.c
@@ -1707,10 +1707,12 @@ DEBUG(MesPrint("Thread %w(f): w=(%d,%d,%d,%d)(%d)",mm[0],mm[1],mm[2],mm[3],C->nu
 				C->rhs[C->numrhs+1] = m;
 				C->Pointer = m;
 				if ( m > C->Top ) {
+/* INTERNAL_ERROR_EXCL_START */
 					MLOCK(ErrorMessageLock);
-					MesPrint("Internal problems with extra compiler buffer");
+					MesPrint("!>Internal problems with extra compiler buffer");
 					MUNLOCK(ErrorMessageLock);
 					Terminate(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 				}
 				goto FlipOn;
 			}
@@ -1732,10 +1734,12 @@ DEBUG(MesPrint("Thread %w(f): w=(%d,%d,%d,%d)(%d)",mm[0],mm[1],mm[2],mm[3],C->nu
 			m++; w += w[1];
 		} while ( --n > 0 );
 	}
+/* INTERNAL_ERROR_EXCL_START */
 	MLOCK(ErrorMessageLock);
-	MesPrint("Bug in AddWild.");
+	MesPrint("!>Bug in AddWild.");
 	MUNLOCK(ErrorMessageLock);
 	return(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 FlipOn:
 	if ( i >= 0 ) {
 		m = AT.WildMask;
@@ -1748,9 +1752,11 @@ FlipOn:
 			}
 			m++; w += w[1];
 		}
+/* INTERNAL_ERROR_EXCL_START */
 		MLOCK(ErrorMessageLock);
-		MesPrint(" Bug in AddWild with passing set[i]");
+		MesPrint("!>Bug in AddWild with passing set[i]");
 		MUNLOCK(ErrorMessageLock);
+/* INTERNAL_ERROR_EXCL_STOP */
 /*
 		For the moment we want to crash here. That is easier with debugging.
 */
@@ -2128,13 +2134,15 @@ int CheckWild(PHEAD WORD oldnumber, WORD type, WORD newnumber, WORD *newval)
 			} while ( --n > 0 );
 			break;
 	}
+/* INTERNAL_ERROR_EXCL_START */
 	AN.oldtype = -1;
 	AN.oldvalue = -1;
 	AN.WildReserve = 0;
 	MLOCK(ErrorMessageLock);
-	MesPrint("Inconsistency in Wildcard prototype.");
+	MesPrint("!>Inconsistency in Wildcard prototype.");
 	MUNLOCK(ErrorMessageLock);
 	return(-1);
+/* INTERNAL_ERROR_EXCL_STOP */
 NoMatch:
 	AN.WildReserve = 0;
 	return(1+retblock);


### PR DESCRIPTION
Mark internal errors with:
/* INTERNAL_ERROR_EXCL_START */
/* INTERNAL_ERROR_EXCL_STOP */

These errors signify bugs in FORM and errors reading/writing from files, etc. In short, one could not reasonably be expected to write test cases which verify the error message. Marking them with the exclusion markers makes this clear in the code.