### PR TITLE
fix(grcc): bounds checking for coupling, nodes, etc

### DIFF
--- a/sources/grcc.cc
+++ b/sources/grcc.cc
@@ -1986,7 +1986,7 @@ Model::Model(MInput *minp)
     }
     name    = strdup(minp->name);
     ncouple = minp->ncouple;
-    if (ncouple >= GRCC_MAXNCPLG) {
+    if (ncouple > GRCC_MAXNCPLG) {
         erEnd("too many coupling constants in the model (GRCC_MAXNCPLG)");
     }
     // cnlist = minp->cnamlist;
@@ -2957,7 +2957,7 @@ SProcess::SProcess(Model *mdl, Process *prc, Options *opts, int sid, int *clst, 
         ok = False;
     }
     nNodes = nvrt + nExtern;
-    if (nNodes >= GRCC_MAXNODES) {
+    if (nNodes > GRCC_MAXNODES) {
         if (prlevel > 0) {
             grcc_fprintf(GRCC_Stderr, "*** SProcess::SProcess: ");
             grcc_fprintf(GRCC_Stderr, "too many nodes = %d\n", nNodes);
@@ -3120,7 +3120,7 @@ SProcess::SProcess(Model *mdl, Process *prc, Options *opts, int sid, int *clst, 
         ok = False;
     }
     nNodes = nvrt + nExtern;
-    if (nNodes >= GRCC_MAXNODES) {
+    if (nNodes > GRCC_MAXNODES) {
         if (prlevel > 0) {
             grcc_fprintf(GRCC_Stderr, "*** SProcess::SProcess: ");
             grcc_fprintf(GRCC_Stderr, "too many nodes = %d\n", nNodes);
@@ -10318,7 +10318,7 @@ void AStack::pushNode(int n)
         erEnd("N-stack overflow (GRCC_MAXNSTACK)");
     }
     nc = agraph->nodes[n]->cand;
-    if (nc->nilist >= GRCC_MAXMINTERACT) {
+    if (nc->nilist > GRCC_MAXMINTERACT) {
         erEnd("N-stack: too long list (GRCC_MAXMINTERACT)");
     }
     ns = nStack[nStackP];
@@ -10348,7 +10348,7 @@ void AStack::pushEdge(int e)
         erEnd("E-stack overflow (GRCC_MAXESTACK)");
     }
     ec = agraph->edges[e]->cand;
-    if (ec->nplist >= GRCC_MAXMPARTICLES2) {
+    if (ec->nplist > GRCC_MAXMPARTICLES2) {
         erEnd("E-stack: Too long list (GRCC_MAXMPARTICLES)");
     }
     es = eStack[eStackP];

--- a/sources/grccparam.h
+++ b/sources/grccparam.h
@@ -32,8 +32,8 @@
 #define GRCC_NAMESPACE
 */
 
-#define GRCC_MAXNCPLG         4
-#define GRCC_MAXLEGS         10
+#define GRCC_MAXNCPLG        15
+#define GRCC_MAXLEGS         15
 #define GRCC_MAXMPARTICLES   50
 #define GRCC_MAXMINTERACT   500
 #define GRCC_MAXSUBPROCS    500


### PR DESCRIPTION
Cases where we check an array index against, for eg, GRCC_MAXNCPLG should use > and not >=. Cases where we are inserting a new vector entry must remain >= since we about to increment, and then index.

Also increase the default GRCC_MAXNCPLG and GRCC_MAXLEGS to 15.

---

Not all cases should be `>` rather than `>=`. For eg, here
https://github.com/form-dev/form/blob/b7753d5beed71d44ce0182e410c596f351ae12cf/sources/grcc.cc#L2135-L2137
we check for `nParticles >= GRCC_MAXMPARTICLES` because below we increment before using `nParticles` as an index:
https://github.com/form-dev/form/blob/b7753d5beed71d44ce0182e410c596f351ae12cf/sources/grcc.cc#L2168-L2169

Fixes #887 