### PR TITLE
ci: use Debian 12 for 32-bit container tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -240,7 +240,7 @@ jobs:
     name: 32-bit container check for ${{ matrix.bin }}${{ matrix.nthreads && format(' -w{0}', matrix.nthreads) || '' }}
     runs-on: ubuntu-latest
     container:
-      image: i386/debian:11.5
+      image: i386/debian:12.15
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Debian 11 (Bullseye) has reached the end of [LTS](https://wiki.debian.org/LTS). Now `apt-get update` fails with a message like:
```
E: Release file for http://deb.debian.org/debian-security/dists/bullseye-security/InRelease is expired (invalid since 12h 12min 55s). Updates for this repository will not be applied.
```

This PR upgrades the 32-bit Debian image from 11 to 12 (Bookworm) to avoid this error.

Note that Debian 13 (Trixie) is also available, but [i386 is no longer supported as a regular architecture](https://www.debian.org/releases/trixie/release-notes/issues.html#reduced-support-for-i386).
