### PR TITLE
perf: improve TFORM CopySpectator performance

### DIFF
--- a/sources/threads.c
+++ b/sources/threads.c
@@ -2667,7 +2667,11 @@ int ThreadsProcessor(EXPRESSIONS e, WORD LastExpression, WORD fromspectator)
 	The number of terms in the expression is in e->counter
 */
 	thrbufsiz2 = thrbufsiz = AC.ThreadBucketSize-1;
-	if ( ( e->counter / ( numberofworkers * 5 ) ) < thrbufsiz ) {
+	/* CopySpectator expressions have a one-term expression prototype in the
+	 * scratch file, regardless of how many terms the spectator contains. Don't
+	 * use this prototype to determine bucket size, or we'll end up with single-term
+	 * buckets and bad performance. Just use thrbufsiz in this case. */
+	if ( ! fromspectator && ( e->counter / ( numberofworkers * 5 ) ) < thrbufsiz ) {
 		thrbufsiz = e->counter / ( numberofworkers * 5 ) - 1;
 		if ( thrbufsiz < 0 ) thrbufsiz = 0;
 	}
@@ -2922,7 +2926,9 @@ Found2:;
 /*
 			There is room in the bucket. Fill yet another term.
 */
-			if ( GetTermP(B0,tt) == 0 ) { endofinput = 1; break; }
+			if ( ( fromspectator
+				? GetFromSpectator(tt,fromspectator-1)
+				: GetTermP(B0,tt) ) == 0 ) { endofinput = 1; break; }
 			dd++;
 			thr->totnum++;
 			dd += AN0.deferskipped;
@@ -2973,7 +2979,9 @@ Found2:;
 /*
 				There is room in the bucket. Fill yet another term.
 */
-				if ( GetTermP(B0,tt) == 0 ) { endofinput = 1; break; }
+				if ( ( fromspectator
+					? GetFromSpectator(tt,fromspectator-1)
+					: GetTermP(B0,tt) ) == 0 ) { endofinput = 1; break; }
 /*
 				Same bracket?
 */


### PR DESCRIPTION
This is a small change to how spectator terms are distributed to TFORM workers. Previously, we ended up creating a huge number of single-term buckets, spoiling efficiency. This now fills the buckets properly.

For a simple benchmark:
```
#-

#: ScratchSize 500M

Off ThreadStats;
On HumanStats;
On SortVerbose;

Symbol x,n;
CFunction sum;

#ifndef `NTERMS'
	#define NTERMS "{2^25}"
#endif
#define PARTS "{2^6}"
#define TERMSPERPART "{`NTERMS'/`PARTS'}"

Local test = - `NTERMS'*(`NTERMS'+1)/2
	#do p = 0,{`PARTS'-2}
		+ sum(n,{`p'*`TERMSPERPART'+1},{(`p'+1)*`TERMSPERPART'},x^n)
	#enddo
	+ sum(n,{(`PARTS'-1)*`TERMSPERPART'+1},`NTERMS',x^n);
.sort:input-1;
Identify sum(?a) = sum_(?a);
.sort:input-2;

CreateSpectator spec "tmp.`PID_'.spec";

Identify x^n?pos_ = n;
ToSpectator spec;
.sort:to-spec;

CopySpectator zero = spec;
.sort:copy-spec;

Print;
.end
```
on my usual benchmark machine, with `tform -w12`, the runtime drops from `32.676 s ± 1.053 s` to `13.639 s ± 0.423 s`.

The `form-bench` tests which use spectators don't see any significant improvement.

| Benchmark | tform-master -w12 runtime (s) | tform-copyspec -w12 speedup |
|:---|---:|---:|
| forcer | 39.24 ± 0.18 s | 1.01 ± 0.01 |
| forcer-exp | 65.29 ± 0.33 s | 1.01 ± 0.01 |
| hyperform | 32.84 ± 0.21 s | 0.99 ± 0.03 |

The (non-public) forcer-based benchmark from Andreas also sees essentially no change (tentative 1%?)
| Benchmark | tform-master -w12 runtime (s) | tform-copyspec -w12 speedup |
|:---|---:|---:|
| forcer-av POW=6 | 61.88 ± 0.35 s | 1.01 ± 0.01 |
| forcer-av POW=8 | 177.11 ± 0.08 s | 1.00 ± 0.00 |
| forcer-av POW=10 | 483.52 ± 1.40 s | 1.01 ± 0.00 |